### PR TITLE
 Automatic formatting with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,46 @@
+---
+Language:      Cpp
+Standard:      Cpp11
+BasedOnStyle:  LLVM
+
+# Basic settings
+UseTab: Never
+ColumnLimit: 80
+IndentWidth: 4
+TabWidth:    4
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth:           4
+
+# Try to preserve merge-friendly diff.
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine:  Empty
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations:   true
+BinPackArguments:  false
+BinPackParameters: false
+
+# Breaking style
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: WebKit
+
+# Include
+IncludeCategories:
+  - Regex:           '^<.*[^h]>'
+    Priority:        -2  # Standard header firsts.
+  - Regex:           '^<.*'
+    Priority:        -1  # "System" header next.
+  - Regex:           '^".*'
+    Priority:        0   # Local header last.
+IncludeIsMainRegex: '(test_)?$'
+
+# Macros
+# To update if we ever use macros that acts as block/foreach.
+ForEachMacros:   []
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+
+# Misc.
+KeepEmptyLinesAtTheStartOfBlocks: false
+PointerAlignment: Left
+...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to QuadIron
+
+## Coding Rules
+
+To ensure consistency throughout the source code, please format your code using
+`clang-format` before submitting a pull request.
+
+`clang-format` can be integrated with several text editor such as Emacs and Vim,
+see the [documentation](https://clang.llvm.org/docs/ClangFormat.html)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,3 @@
-
 CC = clang++
 
 CFLAGS = -std=c++11 -g -Wall -Werror -DHAVE_READLINE

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -5,31 +5,31 @@
 #ifndef BITCOIN_BIGNUM_H
 #define BITCOIN_BIGNUM_H
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 #include <openssl/bn.h>
-#include <algorithm>
 
 //#include "util.h" // for uint64
-typedef long long  int64;
-typedef unsigned long long  uint64;
+typedef long long int64;
+typedef unsigned long long uint64;
 
 /** Errors thrown by the bignum class */
-class bignum_error : public std::runtime_error
-{
-public:
+class bignum_error : public std::runtime_error {
+  public:
     explicit bignum_error(const std::string& str) : std::runtime_error(str) {}
 };
 
-
 /** RAII encapsulated BN_CTX (OpenSSL bignum context) */
-class CAutoBN_CTX
-{
-protected:
+class CAutoBN_CTX {
+  protected:
     BN_CTX* pctx;
-    BN_CTX* operator=(BN_CTX* pnew) { return pctx = pnew; }
+    BN_CTX* operator=(BN_CTX* pnew)
+    {
+        return pctx = pnew;
+    }
 
-public:
+  public:
     CAutoBN_CTX()
     {
         pctx = BN_CTX_new();
@@ -43,17 +43,27 @@ public:
             BN_CTX_free(pctx);
     }
 
-    operator BN_CTX*() { return pctx; }
-    BN_CTX& operator*() { return *pctx; }
-    BN_CTX** operator&() { return &pctx; }
-    bool operator!() { return (pctx == NULL); }
+    operator BN_CTX*()
+    {
+        return pctx;
+    }
+    BN_CTX& operator*()
+    {
+        return *pctx;
+    }
+    BN_CTX** operator&()
+    {
+        return &pctx;
+    }
+    bool operator!()
+    {
+        return (pctx == NULL);
+    }
 };
 
-
 /** C++ wrapper for BIGNUM (OpenSSL bignum) */
-class CBigNum : public BIGNUM
-{
-public:
+class CBigNum : public BIGNUM {
+  public:
     CBigNum()
     {
         BN_init(this);
@@ -62,10 +72,10 @@ public:
     CBigNum(const CBigNum& b)
     {
         BN_init(this);
-        if (!BN_copy(this, &b))
-        {
+        if (!BN_copy(this, &b)) {
             BN_clear_free(this);
-            throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
+            throw bignum_error(
+                "CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
         }
     }
 
@@ -81,17 +91,69 @@ public:
         BN_clear_free(this);
     }
 
-    //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
-    CBigNum(signed char n)      { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(short n)            { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int n)              { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long n)             { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int64 n)            { BN_init(this); setint64(n); }
-    CBigNum(unsigned char n)    { BN_init(this); setulong(n); }
-    CBigNum(unsigned short n)   { BN_init(this); setulong(n); }
-    CBigNum(unsigned int n)     { BN_init(this); setulong(n); }
-    CBigNum(unsigned long n)    { BN_init(this); setulong(n); }
-    CBigNum(uint64 n)           { BN_init(this); setuint64(n); }
+    // CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
+    CBigNum(signed char n)
+    {
+        BN_init(this);
+        if (n >= 0)
+            setulong(n);
+        else
+            setint64(n);
+    }
+    CBigNum(short n)
+    {
+        BN_init(this);
+        if (n >= 0)
+            setulong(n);
+        else
+            setint64(n);
+    }
+    CBigNum(int n)
+    {
+        BN_init(this);
+        if (n >= 0)
+            setulong(n);
+        else
+            setint64(n);
+    }
+    CBigNum(long n)
+    {
+        BN_init(this);
+        if (n >= 0)
+            setulong(n);
+        else
+            setint64(n);
+    }
+    CBigNum(int64 n)
+    {
+        BN_init(this);
+        setint64(n);
+    }
+    CBigNum(unsigned char n)
+    {
+        BN_init(this);
+        setulong(n);
+    }
+    CBigNum(unsigned short n)
+    {
+        BN_init(this);
+        setulong(n);
+    }
+    CBigNum(unsigned int n)
+    {
+        BN_init(this);
+        setulong(n);
+    }
+    CBigNum(unsigned long n)
+    {
+        BN_init(this);
+        setulong(n);
+    }
+    CBigNum(uint64 n)
+    {
+        BN_init(this);
+        setuint64(n);
+    }
 #if 0
     explicit CBigNum(uint256 n) { BN_init(this); setuint256(n); }
 #endif
@@ -105,7 +167,8 @@ public:
     void setulong(unsigned long n)
     {
         if (!BN_set_word(this, n))
-            throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
+            throw bignum_error(
+                "CBigNum conversion from unsigned long : BN_set_word failed");
     }
 
     unsigned long getulong() const
@@ -136,11 +199,12 @@ public:
         bool fNegative;
         uint64 n;
 
-        if (sn < (int64)0)
-        {
-            // Since the minimum signed integer cannot be represented as positive so long as its type is signed, 
-            // and it's not well-defined what happens if you make it unsigned before negating it,
-            // we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
+        if (sn < (int64)0) {
+            // Since the minimum signed integer cannot be represented as
+            // positive so long as its type is signed, and it's not well-defined
+            // what happens if you make it unsigned before negating it, we
+            // instead increment the negative integer by 1, convert it, then
+            // increment the (now positive) unsigned integer by 1 to compensate
             n = -(sn + 1);
             ++n;
             fNegative = true;
@@ -150,12 +214,10 @@ public:
         }
 
         bool fLeadingZeroes = true;
-        for (int i = 0; i < 8; i++)
-        {
+        for (int i = 0; i < 8; i++) {
             unsigned char c = (n >> 56) & 0xff;
             n <<= 8;
-            if (fLeadingZeroes)
-            {
+            if (fLeadingZeroes) {
                 if (c == 0)
                     continue;
                 if (c & 0x80)
@@ -170,7 +232,7 @@ public:
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
-        pch[3] = (nSize) & 0xff;
+        pch[3] = (nSize)&0xff;
         BN_mpi2bn(pch, p - pch, this);
     }
 
@@ -179,12 +241,10 @@ public:
         unsigned char pch[sizeof(n) + 6];
         unsigned char* p = pch + 4;
         bool fLeadingZeroes = true;
-        for (int i = 0; i < 8; i++)
-        {
+        for (int i = 0; i < 8; i++) {
             unsigned char c = (n >> 56) & 0xff;
             n <<= 8;
-            if (fLeadingZeroes)
-            {
+            if (fLeadingZeroes) {
                 if (c == 0)
                     continue;
                 if (c & 0x80)
@@ -197,7 +257,7 @@ public:
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
-        pch[3] = (nSize) & 0xff;
+        pch[3] = (nSize)&0xff;
         BN_mpi2bn(pch, p - pch, this);
     }
 
@@ -257,7 +317,7 @@ public:
         vch2[2] = (nSize >> 8) & 0xff;
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
-	reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
+        reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
         BN_mpi2bn(&vch2[0], vch2.size(), this);
     }
 
@@ -298,17 +358,14 @@ public:
     CBigNum& SetCompact(unsigned int nCompact)
     {
         unsigned int nSize = nCompact >> 24;
-        bool fNegative     =(nCompact & 0x00800000) != 0;
+        bool fNegative = (nCompact & 0x00800000) != 0;
         unsigned int nWord = nCompact & 0x007fffff;
-        if (nSize <= 3)
-        {
-            nWord >>= 8*(3-nSize);
+        if (nSize <= 3) {
+            nWord >>= 8 * (3 - nSize);
             BN_set_word(this, nWord);
-        }
-        else
-        {
+        } else {
             BN_set_word(this, nWord);
-            BN_lshift(this, this, 8*(nSize-3));
+            BN_lshift(this, this, 8 * (nSize - 3));
         }
         BN_set_negative(this, fNegative);
         return *this;
@@ -319,17 +376,16 @@ public:
         unsigned int nSize = BN_num_bytes(this);
         unsigned int nCompact = 0;
         if (nSize <= 3)
-            nCompact = BN_get_word(this) << 8*(3-nSize);
-        else
-        {
+            nCompact = BN_get_word(this) << 8 * (3 - nSize);
+        else {
             CBigNum bn;
-            BN_rshift(&bn, this, 8*(nSize-3));
+            BN_rshift(&bn, this, 8 * (nSize - 3));
             nCompact = BN_get_word(&bn);
         }
         // The 0x00800000 bit denotes the sign.
-        // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
-        if (nCompact & 0x00800000)
-        {
+        // Thus, if it is already set, divide the mantissa by 256 and increase
+        // the exponent.
+        if (nCompact & 0x00800000) {
             nCompact >>= 8;
             nSize++;
         }
@@ -345,8 +401,7 @@ public:
         while (isspace(*psz))
             psz++;
         bool fNegative = false;
-        if (*psz == '-')
-        {
+        if (*psz == '-') {
             fNegative = true;
             psz++;
         }
@@ -356,10 +411,16 @@ public:
             psz++;
 
         // hex string to bignum
-        static const signed char phexdigit[256] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,1,2,3,4,5,6,7,8,9,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0 };
+        static const signed char phexdigit[256] = {
+            0, 0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1,   2,   3,   4,   5,   6,   7, 8, 9, 0, 0, 0, 0, 0, 0,
+            0, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         *this = 0;
-        while (isxdigit(*psz))
-        {
+        while (isxdigit(*psz)) {
             *this <<= 4;
             int n = phexdigit[(unsigned char)*psz++];
             *this += n;
@@ -368,7 +429,7 @@ public:
             *this = 0 - *this;
     }
 
-    std::string ToString(int nBase=10) const
+    std::string ToString(int nBase = 10) const
     {
         CAutoBN_CTX pctx;
         CBigNum bnBase = nBase;
@@ -380,8 +441,7 @@ public:
         CBigNum rem;
         if (BN_cmp(&bn, &bn0) == 0)
             return "0";
-        while (BN_cmp(&bn, &bn0) > 0)
-        {
+        while (BN_cmp(&bn, &bn0) > 0) {
             if (!BN_div(&dv, &rem, &bn, &bnBase, pctx))
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             bn = dv;
@@ -401,9 +461,9 @@ public:
 
     /**
      * Returns the number of bits in a CBigNum
-     * 
+     *
      * This is used by Kademlia to figure out which bucket nodes go in
-     * 
+     *
      * bit_length( 0 ) returns 0
      * bit_length( 1 ) returns 1
      * bit_length( 2 ) returns 2
@@ -412,21 +472,21 @@ public:
      * bit_length( 5 ) returns 3
      * bit_length( 6 ) returns 3
      * bit_length( 7 ) returns 3
-     * 
+     *
      * ... and so on
-     * 
+     *
      * @return The number of bits
      */
     inline int bit_length()
     {
-      return BN_num_bits(this);
+        return BN_num_bits(this);
     }
 
     inline void Rand(int n_bits)
     {
-      CBigNum range = 0;
-      BN_set_bit(&range, n_bits);
-      BN_rand_range(this, &range);
+        CBigNum range = 0;
+        BN_set_bit(&range, n_bits);
+        BN_rand_range(this, &range);
     }
 
 #if 0
@@ -497,12 +557,13 @@ public:
 
     CBigNum& operator>>=(unsigned int shift)
     {
-        // Note: BN_rshift segfaults on 64-bit if 2^shift is greater than the number
-        //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
+        // Note: BN_rshift segfaults on 64-bit if 2^shift is greater than the
+        // number
+        //   if built on ubuntu 9.04 or 9.10, probably depends on version of
+        //   OpenSSL
         CBigNum a = 1;
         a <<= shift;
-        if (BN_cmp(&a, this) > 0)
-        {
+        if (BN_cmp(&a, this) > 0) {
             *this = 0;
             return *this;
         }
@@ -511,7 +572,6 @@ public:
             throw bignum_error("CBigNum:operator>>= : BN_rshift failed");
         return *this;
     }
-
 
     CBigNum& operator++()
     {
@@ -547,13 +607,10 @@ public:
         return ret;
     }
 
-
     friend inline const CBigNum operator-(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator/(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator%(const CBigNum& a, const CBigNum& b);
 };
-
-
 
 inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 {
@@ -628,11 +685,29 @@ inline const CBigNum operator^(const CBigNum& a, const CBigNum& b)
     return r;
 }
 
-inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) == 0); }
-inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) != 0); }
-inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) <= 0); }
-inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) >= 0); }
-inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) < 0); }
-inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) > 0); }
+inline bool operator==(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) == 0);
+}
+inline bool operator!=(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) != 0);
+}
+inline bool operator<=(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) <= 0);
+}
+inline bool operator>=(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) >= 0);
+}
+inline bool operator<(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) < 0);
+}
+inline bool operator>(const CBigNum& a, const CBigNum& b)
+{
+    return (BN_cmp(&a, &b) > 0);
+}
 
 #endif

--- a/src/bit_map.cpp
+++ b/src/bit_map.cpp
@@ -1,86 +1,80 @@
 
 #include "kadsim.h"
 
-void 
-BitMap::shuffle()
+void BitMap::shuffle()
 {
-  for (int i = 0;i < n_bits;i++)
-    reservoir[i] = i;
+    for (int i = 0; i < n_bits; i++)
+        reservoir[i] = i;
 
-  for (int i = n_bits-1;i > 0;--i)
-    {
-      int j = rand() % i;
-      int tmp = reservoir[j];
-      reservoir[j] = reservoir[i];
-      reservoir[i] = tmp;
+    for (int i = n_bits - 1; i > 0; --i) {
+        int j = rand() % i;
+        int tmp = reservoir[j];
+        reservoir[j] = reservoir[i];
+        reservoir[i] = tmp;
     }
 }
 
-/** 
+/**
  * check that all bits are taken
- * 
+ *
  */
-bool
-BitMap::check()
+bool BitMap::check()
 {
-  for (int i = 0;i < n_bits;i++)
-    if (get_bit(i))
-      return false;
+    for (int i = 0; i < n_bits; i++)
+        if (get_bit(i))
+            return false;
 
-  return true;
+    return true;
 }
 
 BitMap::BitMap(int n_bits)
 {
-  this->n_bits = n_bits;
+    this->n_bits = n_bits;
 
-  b = new char[(n_bits + 7)/8]();
+    b = new char[(n_bits + 7) / 8]();
 
-  reservoir = new int[n_bits];
-  shuffle();
-  pos = 0;
+    reservoir = new int[n_bits];
+    shuffle();
+    pos = 0;
 }
 
 BitMap::~BitMap()
 {
-  delete [] b;
+    delete[] b;
 }
 
 void BitMap::set_bit(int i)
 {
-  b[i / 8] |= 1 << (i & 7);
+    b[i / 8] |= 1 << (i & 7);
 }
 
 void BitMap::clear_bit(int i)
 {
-  b[i / 8] &= ~(1 << (i & 7));
+    b[i / 8] &= ~(1 << (i & 7));
 }
 
 int BitMap::get_bit(int i)
 {
-  return b[i / 8] & (1 << (i & 7)) ? 1 : 0;
+    return b[i / 8] & (1 << (i & 7)) ? 1 : 0;
 }
 
 int BitMap::get_rand_bit()
 {
-  if (pos < n_bits)
-    {
-      int bit = reservoir[pos];
+    if (pos < n_bits) {
+        int bit = reservoir[pos];
 
-      //std::cout << "pos " << pos << " bit " << bit << std::endl;
+        // std::cout << "pos " << pos << " bit " << bit << std::endl;
 
-      if (get_bit(bit) != 0)
-	{
-	  std::cout << "error pos " << pos << " bit " << bit << " is already set" << std::endl;
-	  exit(EXIT_FAILURE);
-	}
-      set_bit(bit);
-      pos++;
-      return bit;
-    }
-  else
-    {
-      std::cout << "error pos=" << pos << " nbits=" << n_bits << std::endl;
-      exit(EXIT_FAILURE);
+        if (get_bit(bit) != 0) {
+            std::cout << "error pos " << pos << " bit " << bit
+                      << " is already set" << std::endl;
+            exit(EXIT_FAILURE);
+        }
+        set_bit(bit);
+        pos++;
+        return bit;
+    } else {
+        std::cout << "error pos=" << pos << " nbits=" << n_bits << std::endl;
+        exit(EXIT_FAILURE);
     }
 }

--- a/src/bit_map.cpp
+++ b/src/bit_map.cpp
@@ -1,4 +1,3 @@
-
 #include "kadsim.h"
 
 void BitMap::shuffle()
@@ -14,10 +13,7 @@ void BitMap::shuffle()
     }
 }
 
-/**
- * check that all bits are taken
- *
- */
+/** Check that all bits are taken. */
 bool BitMap::check()
 {
     for (int i = 0; i < n_bits; i++)

--- a/src/bit_map.h
+++ b/src/bit_map.h
@@ -4,28 +4,28 @@
 
 #include "kadsim.h"
 
-class BitMap
-{
- public:
-  BitMap(int n_bits);
-  ~BitMap();
+class BitMap {
+  public:
+    BitMap(int n_bits);
+    ~BitMap();
 
-  int get_bit(int i);
-  int get_rand_bit(); /* get a random bit that has never been generated before */
-  bool check();
+    int get_bit(int i);
+    int
+    get_rand_bit(); /* get a random bit that has never been generated before */
+    bool check();
 
- private:
-  //DISALLOW_COPY_AND_ASSIGN(BitMap);
+  private:
+    // DISALLOW_COPY_AND_ASSIGN(BitMap);
 
-  int n_bits;
-  char *b;
-  int *reservoir;
-  int pos;
+    int n_bits;
+    char* b;
+    int* reservoir;
+    int pos;
 
-  void set_bit(int i);
-  void clear_bit(int i);
+    void set_bit(int i);
+    void clear_bit(int i);
 
-  void shuffle();
+    void shuffle();
 };
 
 #endif

--- a/src/bit_map.h
+++ b/src/bit_map.h
@@ -1,4 +1,3 @@
-
 #ifndef __BITMAP_H__
 #define __BITMAP_H__ 1
 
@@ -11,7 +10,7 @@ class BitMap {
 
     int get_bit(int i);
     int
-    get_rand_bit(); /* get a random bit that has never been generated before */
+    get_rand_bit(); /* Get a random bit that has never been generated before. */
     bool check();
 
   private:

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -1,4 +1,3 @@
-
 #include "kadsim.h"
 
 int cmd_quit(Shell* shell, int argc, char** argv)
@@ -105,8 +104,6 @@ int cmd_lookup(Shell* shell, int argc, char** argv)
     bn.SetHex(argv[1]);
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
-    // std::cout << bn.ToString(16) << "\n";
-
     std::list<KadNode*> result = node->lookup(routable);
 
     std::list<KadNode*>::iterator it;
@@ -134,8 +131,6 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
     CBigNum bn;
     bn.SetHex(argv[1]);
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
-
-    // std::cout << bn.ToString(16) << "\n";
 
     std::list<KadNode*> result =
         node->find_nearest_nodes(routable, atoi(argv[2]));

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -1,436 +1,380 @@
 
 #include "kadsim.h"
 
-int
-cmd_quit(Shell *shell,
-	 int argc,
-	 char **argv)
+int cmd_quit(Shell* shell, int argc, char** argv)
 {
-  return SHELL_RETURN;
+    return SHELL_RETURN;
 }
 
-int
-cmd_help(Shell *shell,
-	 int argc,
-	 char **argv)
+int cmd_help(Shell* shell, int argc, char** argv)
 {
-  if (argc == 1)
-    {
-      struct cmd_def *cmdp;
-      int i, j;
+    if (argc == 1) {
+        struct cmd_def* cmdp;
+        int i, j;
 
-      j = 0;
-      for (i = 0;cmd_defs[i];i++)
-	{
-          cmdp = cmd_defs[i];
-	  printf("%16s", cmdp->name);
-	  j++;
-	  if (j == 4)
-	    {
-	      printf("\n");
-	      j = 0;
-	    }
-	}
-      printf("\n");
-    }
-  else if (argc == 2)
-    {
-      struct cmd_def *cmdp;
-      int i;
+        j = 0;
+        for (i = 0; cmd_defs[i]; i++) {
+            cmdp = cmd_defs[i];
+            printf("%16s", cmdp->name);
+            j++;
+            if (j == 4) {
+                printf("\n");
+                j = 0;
+            }
+        }
+        printf("\n");
+    } else if (argc == 2) {
+        struct cmd_def* cmdp;
+        int i;
 
-      for (i = 0;cmd_defs[i];i++)
-	{
-          cmdp = cmd_defs[i];
-	  if (!strcmp(argv[1], cmdp->name))
-	    {
-	      printf("%s\n", cmdp->purpose);
-	      break ;
-	    }
-	}
+        for (i = 0; cmd_defs[i]; i++) {
+            cmdp = cmd_defs[i];
+            if (!strcmp(argv[1], cmdp->name)) {
+                printf("%s\n", cmdp->purpose);
+                break;
+            }
+        }
     }
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-void
-cb_display_node(KadNode *node,
-	  void *cb_arg)
+void cb_display_node(KadNode* node, void* cb_arg)
 {
-  std::cout << node->get_id().ToString(16) << "\n";
+    std::cout << node->get_id().ToString(16) << "\n";
 }
 
-void
-cb_display_routable(KadRoutable routable,
-		    void *cb_arg)
+void cb_display_routable(KadRoutable routable, void* cb_arg)
 {
-  std::cout << routable.get_id().ToString(16) << "\n";
+    std::cout << routable.get_id().ToString(16) << "\n";
 }
 
-int
-cmd_rand_node(Shell *shell,
-	      int argc,
-	      char **argv)
+int cmd_rand_node(Shell* shell, int argc, char** argv)
 {
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  network->rand_node(cb_display_node, NULL);
+    network->rand_node(cb_display_node, NULL);
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_rand_key(Shell *shell,
-	      int argc,
-	      char **argv)
+int cmd_rand_key(Shell* shell, int argc, char** argv)
 {
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  network->rand_routable(cb_display_routable, NULL);
+    network->rand_routable(cb_display_routable, NULL);
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_jump(Shell *shell,
-	 int argc,
-	 char **argv)
+int cmd_jump(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: jump key\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: jump key\n");
+        return SHELL_CONT;
     }
 
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  KadNode *node = network->lookup_cheat(argv[1]);
-  if (NULL == node)
-    {
-      fprintf(stderr, "not found\n");
-      return SHELL_CONT;
+    KadNode* node = network->lookup_cheat(argv[1]);
+    if (NULL == node) {
+        fprintf(stderr, "not found\n");
+        return SHELL_CONT;
     }
 
-  shell->set_handle2(node);
-  
-  return SHELL_CONT;
+    shell->set_handle2(node);
+
+    return SHELL_CONT;
 }
 
-int
-cmd_lookup(Shell *shell,
-	   int argc,
-	   char **argv)
+int cmd_lookup(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: lookup key\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: lookup key\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
+    KadNode* node = (KadNode*)shell->get_handle2();
 
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  CBigNum bn;
-  bn.SetHex(argv[1]);
-  KadRoutable routable(bn, KAD_ROUTABLE_FILE);
+    CBigNum bn;
+    bn.SetHex(argv[1]);
+    KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
-  //std::cout << bn.ToString(16) << "\n";
+    // std::cout << bn.ToString(16) << "\n";
 
-  std::list<KadNode*> result = node->lookup(routable);
+    std::list<KadNode*> result = node->lookup(routable);
 
-  std::list<KadNode*>::iterator it;
-  for (it = result.begin();it != result.end();++it)
-    std::cout << "id " << (*it)->get_id().ToString(16) << " dist " << (*it)->distance_to(routable).ToString(16) << "\n";
+    std::list<KadNode*>::iterator it;
+    for (it = result.begin(); it != result.end(); ++it)
+        std::cout << "id " << (*it)->get_id().ToString(16) << " dist "
+                  << (*it)->distance_to(routable).ToString(16) << "\n";
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_find_nearest(Shell *shell,
-		 int argc,
-		 char **argv)
+int cmd_find_nearest(Shell* shell, int argc, char** argv)
 {
-  if (argc != 3)
-    {
-      fprintf(stderr, "usage: find_nearest key amount\n");
-      return SHELL_CONT;
+    if (argc != 3) {
+        fprintf(stderr, "usage: find_nearest key amount\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
+    KadNode* node = (KadNode*)shell->get_handle2();
 
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  CBigNum bn;
-  bn.SetHex(argv[1]);
-  KadRoutable routable(bn, KAD_ROUTABLE_FILE);
+    CBigNum bn;
+    bn.SetHex(argv[1]);
+    KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
-  //std::cout << bn.ToString(16) << "\n";
+    // std::cout << bn.ToString(16) << "\n";
 
-  std::list<KadNode*> result = node->find_nearest_nodes(routable, atoi(argv[2]));
+    std::list<KadNode*> result =
+        node->find_nearest_nodes(routable, atoi(argv[2]));
 
-  std::list<KadNode*>::iterator it;
-  for (it = result.begin();it != result.end();++it)
-    std::cout << "id " << (*it)->get_id().ToString(16) << " dist " << (*it)->distance_to(routable).ToString(16) << "\n";
+    std::list<KadNode*>::iterator it;
+    for (it = result.begin(); it != result.end(); ++it)
+        std::cout << "id " << (*it)->get_id().ToString(16) << " dist "
+                  << (*it)->distance_to(routable).ToString(16) << "\n";
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_show(Shell *shell,
-	 int argc,
-	 char **argv)
+int cmd_show(Shell* shell, int argc, char** argv)
 {
-  if (argc != 1)
-    {
-      fprintf(stderr, "usage: show\n");
-      return SHELL_CONT;
+    if (argc != 1) {
+        fprintf(stderr, "usage: show\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
+    KadNode* node = (KadNode*)shell->get_handle2();
 
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  node->show();
+    node->show();
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_verbose(Shell *shell,
-	    int argc,
-	    char **argv)
+int cmd_verbose(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: verbose 1|0\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: verbose 1|0\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
+    KadNode* node = (KadNode*)shell->get_handle2();
 
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  node->set_verbose(atoi(argv[1]));
+    node->set_verbose(atoi(argv[1]));
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_cheat_lookup(Shell *shell,
-		 int argc,
-		 char **argv)
+int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: jump key\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: jump key\n");
+        return SHELL_CONT;
     }
 
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  CBigNum bn;
-  bn.SetHex(argv[1]);
-  KadRoutable routable(bn, KAD_ROUTABLE_FILE);
+    CBigNum bn;
+    bn.SetHex(argv[1]);
+    KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
-  KadNode *node = network->find_nearest_cheat(routable);
-  if (NULL == node)
-    {
-      fprintf(stderr, "not found\n");
-      return SHELL_CONT;
+    KadNode* node = network->find_nearest_cheat(routable);
+    if (NULL == node) {
+        fprintf(stderr, "not found\n");
+        return SHELL_CONT;
     }
-  
-  cb_display_node(node, NULL);
-  
-  return SHELL_CONT;
+
+    cb_display_node(node, NULL);
+
+    return SHELL_CONT;
 }
 
-int
-cmd_save(Shell *shell,
-	 int argc,
-	 char **argv)
+int cmd_save(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: save file\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: save file\n");
+        return SHELL_CONT;
     }
 
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  std::ofstream fout(argv[1]);
-  network->save(fout);
-  
-  return SHELL_CONT;
+    std::ofstream fout(argv[1]);
+    network->save(fout);
+
+    return SHELL_CONT;
 }
 
-int
-cmd_xor(Shell *shell,
-	int argc,
-	char **argv)
+int cmd_xor(Shell* shell, int argc, char** argv)
 {
-  if (argc != 3)
-    {
-      fprintf(stderr, "usage: xor bn1 bn2\n");
-      return SHELL_CONT;
+    if (argc != 3) {
+        fprintf(stderr, "usage: xor bn1 bn2\n");
+        return SHELL_CONT;
     }
 
-  CBigNum bn1;
-  bn1.SetHex(argv[1]);
-  KadRoutable routable1(bn1, KAD_ROUTABLE_FILE);
+    CBigNum bn1;
+    bn1.SetHex(argv[1]);
+    KadRoutable routable1(bn1, KAD_ROUTABLE_FILE);
 
-  CBigNum bn2;
-  bn2.SetHex(argv[2]);
-  KadRoutable routable2(bn2, KAD_ROUTABLE_FILE);
+    CBigNum bn2;
+    bn2.SetHex(argv[2]);
+    KadRoutable routable2(bn2, KAD_ROUTABLE_FILE);
 
-  std::cout << routable1.distance_to(routable2).ToString(16) << "\n";
+    std::cout << routable1.distance_to(routable2).ToString(16) << "\n";
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_bit_length(Shell *shell,
-	       int argc,
-	       char **argv)
+int cmd_bit_length(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: bit_length bn\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: bit_length bn\n");
+        return SHELL_CONT;
     }
 
-  CBigNum bn;
-  bn.SetHex(argv[1]);
+    CBigNum bn;
+    bn.SetHex(argv[1]);
 
-  std::cout << bn.bit_length() << "\n";
+    std::cout << bn.bit_length() << "\n";
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int
-cmd_graphviz(Shell *shell,
-	     int argc,
-	     char **argv)
+int cmd_graphviz(Shell* shell, int argc, char** argv)
 {
-  if (argc != 2)
-    {
-      fprintf(stderr, "usage: graphviz file\n");
-      return SHELL_CONT;
+    if (argc != 2) {
+        fprintf(stderr, "usage: graphviz file\n");
+        return SHELL_CONT;
     }
 
-  KadNetwork *network = (KadNetwork *) shell->get_handle();
+    KadNetwork* network = (KadNetwork*)shell->get_handle();
 
-  std::ofstream fout(argv[1]);
-  network->graphviz(fout);
+    std::ofstream fout(argv[1]);
+    network->graphviz(fout);
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int cmd_buy_storage(Shell *shell, int argc, char **argv)
+int cmd_buy_storage(Shell* shell, int argc, char** argv)
 {
-  if (argc != 3)
-    {
-      fprintf(stderr, "usage: buy_storage SELLER N_BYTES\n");
-      return SHELL_CONT;
+    if (argc != 3) {
+        fprintf(stderr, "usage: buy_storage SELLER N_BYTES\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    KadNode* node = (KadNode*)shell->get_handle2();
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  // FIXME: atoi is so dirty…
-  node->buy_storage(argv[1], atoi(argv[2]));
+    // FIXME: atoi is so dirty…
+    node->buy_storage(argv[1], atoi(argv[2]));
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int cmd_put_bytes(Shell *shell, int argc, char **argv)
+int cmd_put_bytes(Shell* shell, int argc, char** argv)
 {
-  if (argc != 3)
-    {
-      fprintf(stderr, "usage: put_bytes SELLER N_BYTES\n");
-      return SHELL_CONT;
+    if (argc != 3) {
+        fprintf(stderr, "usage: put_bytes SELLER N_BYTES\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    KadNode* node = (KadNode*)shell->get_handle2();
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  // FIXME: atoi is so dirty…
-  node->put_bytes(argv[1], atoi(argv[2]));
+    // FIXME: atoi is so dirty…
+    node->put_bytes(argv[1], atoi(argv[2]));
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
-int cmd_get_bytes(Shell *shell, int argc, char **argv)
+int cmd_get_bytes(Shell* shell, int argc, char** argv)
 {
-  if (argc != 3)
-    {
-      fprintf(stderr, "usage: get_bytes SELLER N_BYTES\n");
-      return SHELL_CONT;
+    if (argc != 3) {
+        fprintf(stderr, "usage: get_bytes SELLER N_BYTES\n");
+        return SHELL_CONT;
     }
 
-  KadNode *node = (KadNode *) shell->get_handle2();
-  if (NULL == node)
-    {
-      fprintf(stderr, "shall jump to a node first\n");
-      return SHELL_CONT;
+    KadNode* node = (KadNode*)shell->get_handle2();
+    if (NULL == node) {
+        fprintf(stderr, "shall jump to a node first\n");
+        return SHELL_CONT;
     }
 
-  // FIXME: atoi is so dirty…
-  node->get_bytes(argv[1], atoi(argv[2]));
+    // FIXME: atoi is so dirty…
+    node->get_bytes(argv[1], atoi(argv[2]));
 
-  return SHELL_CONT;
+    return SHELL_CONT;
 }
 
 struct cmd_def quit_cmd = {"quit", "quit program", cmd_quit};
 struct cmd_def help_cmd = {"help", "help", cmd_help};
 struct cmd_def jump_cmd = {"jump", "jump to a node", cmd_jump};
 struct cmd_def lookup_cmd = {"lookup", "lookup a node", cmd_lookup};
-struct cmd_def cheat_lookup_cmd = {"cheat_lookup", "lookup the closest node by cheating", cmd_cheat_lookup};
-struct cmd_def rand_node_cmd = {"rand_node", "print a random node id", cmd_rand_node};
+struct cmd_def cheat_lookup_cmd = {"cheat_lookup",
+                                   "lookup the closest node by cheating",
+                                   cmd_cheat_lookup};
+struct cmd_def rand_node_cmd = {"rand_node",
+                                "print a random node id",
+                                cmd_rand_node};
 struct cmd_def rand_key_cmd = {"rand_key", "print a random key", cmd_rand_key};
 struct cmd_def show_cmd = {"show", "show k-buckets", cmd_show};
-struct cmd_def find_nearest_cmd = {"find_nearest", "find nearest nodes to", cmd_find_nearest};
+struct cmd_def find_nearest_cmd = {"find_nearest",
+                                   "find nearest nodes to",
+                                   cmd_find_nearest};
 struct cmd_def verbose_cmd = {"verbose", "set verbosity level", cmd_verbose};
 struct cmd_def save_cmd = {"save", "save the network to file", cmd_save};
 struct cmd_def xor_cmd = {"xor", "xor between 2 bignums", cmd_xor};
-struct cmd_def bit_length_cmd = {"bit_length", "bit length of bignum", cmd_bit_length};
-struct cmd_def graphviz_cmd = {"graphviz", "dump a graphviz of the nodes acc/ to their k-buckets", cmd_graphviz};
-struct cmd_def buy_storage_cmd = {"buy_storage", "buy N bytes of storage", cmd_buy_storage};
-struct cmd_def put_bytes_cmd = {"put_bytes", "put N bytes on storage", cmd_put_bytes};
-struct cmd_def get_bytes_cmd = {"get_bytes", "get N bytes from storage", cmd_get_bytes};
+struct cmd_def bit_length_cmd = {"bit_length",
+                                 "bit length of bignum",
+                                 cmd_bit_length};
+struct cmd_def graphviz_cmd = {
+    "graphviz",
+    "dump a graphviz of the nodes acc/ to their k-buckets",
+    cmd_graphviz};
+struct cmd_def buy_storage_cmd = {"buy_storage",
+                                  "buy N bytes of storage",
+                                  cmd_buy_storage};
+struct cmd_def put_bytes_cmd = {"put_bytes",
+                                "put N bytes on storage",
+                                cmd_put_bytes};
+struct cmd_def get_bytes_cmd = {"get_bytes",
+                                "get N bytes from storage",
+                                cmd_get_bytes};
 
-struct cmd_def	*cmd_defs[] =
-  {
+struct cmd_def* cmd_defs[] = {
     &bit_length_cmd,
     &buy_storage_cmd,
     &cheat_lookup_cmd,
     &find_nearest_cmd,
     &get_bytes_cmd,
     &graphviz_cmd,
-    &help_cmd,   
+    &help_cmd,
     &jump_cmd,
     &lookup_cmd,
     &put_bytes_cmd,
@@ -442,5 +386,4 @@ struct cmd_def	*cmd_defs[] =
     &verbose_cmd,
     &xor_cmd,
     NULL,
-  };
-
+};

--- a/src/kad_file.cpp
+++ b/src/kad_file.cpp
@@ -1,18 +1,15 @@
 
 #include "kadsim.h"
 
-KadFile::KadFile(CBigNum id, KadNode *referencer) : KadRoutable(id, KAD_ROUTABLE_FILE)
+KadFile::KadFile(CBigNum id, KadNode* referencer)
+    : KadRoutable(id, KAD_ROUTABLE_FILE)
 {
-  this->referencer = referencer;
+    this->referencer = referencer;
 }
 
-KadFile::~KadFile()
-{
+KadFile::~KadFile() {}
 
-}
-
-KadNode *
-KadFile::get_referencer()
+KadNode* KadFile::get_referencer()
 {
-  return referencer;
+    return referencer;
 }

--- a/src/kad_file.cpp
+++ b/src/kad_file.cpp
@@ -1,4 +1,3 @@
-
 #include "kadsim.h"
 
 KadFile::KadFile(CBigNum id, KadNode* referencer)

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -1,8 +1,8 @@
-#include "kadsim.h"
-
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+
+#include "kadsim.h"
 
 KadNetwork::KadNetwork(KadConf* conf)
 {
@@ -24,12 +24,12 @@ void KadNetwork::initialize_nodes(
 
     BitMap bitmap = BitMap(conf->n_nodes);
 
-    // split the total keyspace equally among nodes
+    // Split the total keyspace equally among nodes.
     CBigNum keyspace = CBigNum(1);
     keyspace = (keyspace << conf->n_bits);
     keyspace /= conf->n_nodes;
 
-    // create nodes
+    // Create nodes.
     for (u_int i = 0; i < conf->n_nodes; i++) {
         std::cerr << "creating node " << i << '\n';
         KadNode* node;
@@ -37,21 +37,21 @@ void KadNetwork::initialize_nodes(
             std::string bstrap = bstraplist.back();
             bstraplist.pop_back();
             std::cout << "create remote node (" << bstrap << ")\n";
-            // create remote node from a bootstrap
+            // Create remote node from a bootstrap.
             node = new KadNode(conf, bitmap.get_rand_bit() * keyspace, bstrap);
         } else {
-            // simulate node
+            // Simulate node.
             node = new KadNode(conf, bitmap.get_rand_bit() * keyspace);
         }
         nodes.push_back(node);
         nodes_map[node->get_id().ToString(16)] = node;
     }
 
-    // there shall be a responsable for every portion of the keyspace
+    // There shall be a responsable for every portion of the keyspace.
     assert(!bitmap.check());
 
-    // continue creating conns for the nodes that dont meet the initial number
-    // required
+    // Continue creating conns for the nodes that dont meet the initial number
+    // required.
     for (u_int i = 0; i < conf->n_nodes; i++) {
         KadNode* node = nodes[i];
 
@@ -70,14 +70,11 @@ void KadNetwork::initialize_nodes(
                 break;
             }
 
-            // pick a random node
+            // Pick a random node.
             int x = rand() % nodes.size();
             other = nodes[x];
 
-            // connect them 2-way
-            // std::cout << "connecting nodes " << node->get_id().ToString(16)
-            // << " (" << node->get_n_conns() << ") and " <<
-            // other->get_id().ToString(16) << "\n";
+            // Connect them 2-way.
             node->add_conn(other, false);
             other->add_conn(node, false);
 
@@ -97,17 +94,17 @@ void KadNetwork::initialize_files(int n_files)
             std::cerr << "file " << i << "/" << n_files
                       << "                   \r";
 
-        // take a random node
+        // Take a random node.
         int x = rand() % nodes.size();
         KadNode* node = nodes[x];
 
-        // gen a random identifier for the file
+        // Gen a random identifier for the file.
         CBigNum bn;
         bn.Rand(conf->n_bits);
         KadFile* file = new KadFile(bn, node);
         files.push_back(file);
 
-        // store file at multiple location
+        // Store file at multiple location.
         std::list<KadNode*> result = node->lookup(*file);
         for (std::list<KadNode*>::iterator it = result.begin();
              it != result.end();
@@ -116,9 +113,7 @@ void KadNetwork::initialize_files(int n_files)
     }
 }
 
-/**
- * check that files are accessible from random nodes
- */
+/** Check that files are accessible from random nodes. */
 void KadNetwork::check_files()
 {
     std::cout << "checking files\n";
@@ -131,14 +126,14 @@ void KadNetwork::check_files()
 
         KadFile* file = files[i];
 
-        // take a random node
+        // Take a random node.
         int x = rand() % nodes.size();
         KadNode* node = nodes[x];
 
-        // get results
+        // Get results.
         std::list<KadNode*> result = node->lookup(*file);
 
-        // check that at least one result has the file
+        // Check that at least one result has the file.
         bool found = false;
         for (std::list<KadNode*>::iterator it = result.begin();
              it != result.end();
@@ -180,20 +175,18 @@ void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
         cb_func(routable, cb_arg);
 }
 
-/**
- * lookup a node by its id
+/** Lookup a node by its id
  *
- * @param id
+ * @param id node IS
  *
- * @return
+ * @return the node identified by `id`
  */
 KadNode* KadNetwork::lookup_cheat(std::string id)
 {
     return nodes_map[id];
 }
 
-/**
- * find node nearest to specified routable
+/** Find node nearest to specified routable.
  *
  * @param routable
  *

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -1,261 +1,248 @@
 #include "kadsim.h"
 
-#include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 
-KadNetwork::KadNetwork(KadConf *conf)
+KadNetwork::KadNetwork(KadConf* conf)
 {
-  this->conf = conf;
+    this->conf = conf;
 }
 
-KadNetwork::~KadNetwork()
-{
+KadNetwork::~KadNetwork() {}
 
-}
-
-/** 
+/**
  * initialize nodes
- * 
- * @param n_init_conn 
+ *
+ * @param n_init_conn
  */
-void 
-KadNetwork::initialize_nodes(int n_init_conn,
-                             std::vector<std::string> bstraplist)
+void KadNetwork::initialize_nodes(
+    int n_init_conn,
+    std::vector<std::string> bstraplist)
 {
-  std::cout << "initialize nodes\n";
+    std::cout << "initialize nodes\n";
 
-  BitMap bitmap = BitMap(conf->n_nodes);
+    BitMap bitmap = BitMap(conf->n_nodes);
 
-  //split the total keyspace equally among nodes
-  CBigNum keyspace = CBigNum(1);
-  keyspace=(keyspace<<conf->n_bits);
-  keyspace/=conf->n_nodes;
+    // split the total keyspace equally among nodes
+    CBigNum keyspace = CBigNum(1);
+    keyspace = (keyspace << conf->n_bits);
+    keyspace /= conf->n_nodes;
 
-  //create nodes
-  for (u_int i = 0;i < conf->n_nodes;i++)
-    {
-      std::cerr << "creating node " << i << '\n';
-      KadNode *node;
-      if (!bstraplist.empty())
-        {
-          std::string bstrap = bstraplist.back();
-          bstraplist.pop_back();
-          std::cout << "create remote node (" << bstrap << ")\n";
-          // create remote node from a bootstrap
-          node = new KadNode(conf, bitmap.get_rand_bit()*keyspace, bstrap);
+    // create nodes
+    for (u_int i = 0; i < conf->n_nodes; i++) {
+        std::cerr << "creating node " << i << '\n';
+        KadNode* node;
+        if (!bstraplist.empty()) {
+            std::string bstrap = bstraplist.back();
+            bstraplist.pop_back();
+            std::cout << "create remote node (" << bstrap << ")\n";
+            // create remote node from a bootstrap
+            node = new KadNode(conf, bitmap.get_rand_bit() * keyspace, bstrap);
+        } else {
+            // simulate node
+            node = new KadNode(conf, bitmap.get_rand_bit() * keyspace);
         }
-      else
-        {
-          // simulate node
-          node = new KadNode(conf, bitmap.get_rand_bit()*keyspace);
-        }
-      nodes.push_back(node);
-      nodes_map[node->get_id().ToString(16)] = node;
+        nodes.push_back(node);
+        nodes_map[node->get_id().ToString(16)] = node;
     }
 
-  //there shall be a responsable for every portion of the keyspace
-  assert(!bitmap.check());
+    // there shall be a responsable for every portion of the keyspace
+    assert(!bitmap.check());
 
-  //continue creating conns for the nodes that dont meet the initial number required
-  for (u_int i = 0;i < conf->n_nodes;i++)
-    {
-      KadNode *node = nodes[i];
+    // continue creating conns for the nodes that dont meet the initial number
+    // required
+    for (u_int i = 0; i < conf->n_nodes; i++) {
+        KadNode* node = nodes[i];
 
-      if ((i % 1000) == 0)
-	std::cerr << "node " << i << "/" << conf->n_nodes << "                   \r";
+        if ((i % 1000) == 0)
+            std::cerr << "node " << i << "/" << conf->n_nodes
+                      << "                   \r";
 
-      u_int guard = 0;
-      while (node->get_n_conns() < n_init_conn)
-	{
-	  KadNode *other;
-	  
-	  if (guard >= (2 * conf->n_nodes))
-	    {
-	      std::cout << "forgiving required conditions for " << node->get_id().ToString(16) << ", it has only " << node->get_n_conns() << " connections\n";
-	      break ;
-	    }
+        u_int guard = 0;
+        while (node->get_n_conns() < n_init_conn) {
+            KadNode* other;
 
-	  //pick a random node
-	  int x = rand() % nodes.size();
-	  other = nodes[x];
-	  
-	  //connect them 2-way
-	  //std::cout << "connecting nodes " << node->get_id().ToString(16) << " (" << node->get_n_conns() << ") and " << other->get_id().ToString(16) << "\n";
-	  node->add_conn(other, false);
-	  other->add_conn(node, false);
+            if (guard >= (2 * conf->n_nodes)) {
+                std::cout << "forgiving required conditions for "
+                          << node->get_id().ToString(16) << ", it has only "
+                          << node->get_n_conns() << " connections\n";
+                break;
+            }
 
-	  guard++;
-	}
-    }  
+            // pick a random node
+            int x = rand() % nodes.size();
+            other = nodes[x];
 
-  std::cout << "\n";
+            // connect them 2-way
+            // std::cout << "connecting nodes " << node->get_id().ToString(16)
+            // << " (" << node->get_n_conns() << ") and " <<
+            // other->get_id().ToString(16) << "\n";
+            node->add_conn(other, false);
+            other->add_conn(node, false);
+
+            guard++;
+        }
+    }
+
+    std::cout << "\n";
 }
 
-void 
-KadNetwork::initialize_files(int n_files)
+void KadNetwork::initialize_files(int n_files)
 {
-  std::cout << "initialize files\n";
+    std::cout << "initialize files\n";
 
-  for (int i = 0;i < n_files;i++)
-    {
-      if ((i % 1000) == 0)
-	std::cerr << "file " << i << "/" << n_files << "                   \r";
+    for (int i = 0; i < n_files; i++) {
+        if ((i % 1000) == 0)
+            std::cerr << "file " << i << "/" << n_files
+                      << "                   \r";
 
-      //take a random node
-      int x = rand() % nodes.size();
-      KadNode *node = nodes[x];
+        // take a random node
+        int x = rand() % nodes.size();
+        KadNode* node = nodes[x];
 
-      //gen a random identifier for the file
-      CBigNum bn;
-      bn.Rand(conf->n_bits);
-      KadFile *file = new KadFile(bn, node);
-      files.push_back(file);
+        // gen a random identifier for the file
+        CBigNum bn;
+        bn.Rand(conf->n_bits);
+        KadFile* file = new KadFile(bn, node);
+        files.push_back(file);
 
-      //store file at multiple location
-      std::list<KadNode*> result = node->lookup(*file);
-      for (std::list<KadNode*>::iterator it = result.begin();it != result.end();++it)
-	(*it)->store(file);
+        // store file at multiple location
+        std::list<KadNode*> result = node->lookup(*file);
+        for (std::list<KadNode*>::iterator it = result.begin();
+             it != result.end();
+             ++it)
+            (*it)->store(file);
     }
 }
 
 /**
  * check that files are accessible from random nodes
  */
-void 
-KadNetwork::check_files()
+void KadNetwork::check_files()
 {
-  std::cout << "checking files\n";
+    std::cout << "checking files\n";
 
-  int n_wrong = 0;
-  for (u_int i = 0;i < files.size();i++)
-    {
-      if ((i % 1000) == 0)
-	std::cerr << "file " << i << "/" << files.size() << "                   \r";
+    int n_wrong = 0;
+    for (u_int i = 0; i < files.size(); i++) {
+        if ((i % 1000) == 0)
+            std::cerr << "file " << i << "/" << files.size()
+                      << "                   \r";
 
-      KadFile *file = files[i];
+        KadFile* file = files[i];
 
-      //take a random node
-      int x = rand() % nodes.size();
-      KadNode *node = nodes[x];
+        // take a random node
+        int x = rand() % nodes.size();
+        KadNode* node = nodes[x];
 
-      //get results
-      std::list<KadNode*> result = node->lookup(*file);
+        // get results
+        std::list<KadNode*> result = node->lookup(*file);
 
-      //check that at least one result has the file
-      bool found = false;
-      for (std::list<KadNode*>::iterator it = result.begin();it != result.end();++it)
-	{
-	  std::vector<KadFile*> node_files = (*it)->get_files();
-	  for (u_int j = 0;j < node_files.size();j++)
-	    {
-	      KadFile *node_file = node_files[j];
-	      if (node_file == file)
-		{
-		  found = true;
-		  break ;
-		}
-	    }
-	}
+        // check that at least one result has the file
+        bool found = false;
+        for (std::list<KadNode*>::iterator it = result.begin();
+             it != result.end();
+             ++it) {
+            std::vector<KadFile*> node_files = (*it)->get_files();
+            for (u_int j = 0; j < node_files.size(); j++) {
+                KadFile* node_file = node_files[j];
+                if (node_file == file) {
+                    found = true;
+                    break;
+                }
+            }
+        }
 
-      if (!found)
-	{
-	  std::cerr << "file " << file->get_id().ToString(16) << " who was referenced by " << file->get_referencer()->get_id().ToString(16) << " was not found\n";
-	  n_wrong++;
-	}
+        if (!found) {
+            std::cerr << "file " << file->get_id().ToString(16)
+                      << " who was referenced by "
+                      << file->get_referencer()->get_id().ToString(16)
+                      << " was not found\n";
+            n_wrong++;
+        }
     }
-  std::cerr << n_wrong << "/" << files.size() << " files wrongly stored\n";
+    std::cerr << n_wrong << "/" << files.size() << " files wrongly stored\n";
 }
 
-void
-KadNetwork::rand_node(tnode_callback_func cb_func,
-		      void *cb_arg)
+void KadNetwork::rand_node(tnode_callback_func cb_func, void* cb_arg)
 {
-  int x = rand() % nodes.size();
-  if (NULL != cb_func)
-    cb_func(nodes[x], cb_arg);
+    int x = rand() % nodes.size();
+    if (NULL != cb_func)
+        cb_func(nodes[x], cb_arg);
 }
 
-void
-KadNetwork::rand_routable(troutable_callback_func cb_func,
-			  void *cb_arg)
+void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
 {
-  CBigNum bn;
-  bn.Rand(conf->n_bits);
-  KadRoutable routable(bn, KAD_ROUTABLE_FILE);
-  if (NULL != cb_func)
-    cb_func(routable, cb_arg);
+    CBigNum bn;
+    bn.Rand(conf->n_bits);
+    KadRoutable routable(bn, KAD_ROUTABLE_FILE);
+    if (NULL != cb_func)
+        cb_func(routable, cb_arg);
 }
 
-/** 
+/**
  * lookup a node by its id
- * 
- * @param id 
- * 
- * @return 
+ *
+ * @param id
+ *
+ * @return
  */
-KadNode *
-KadNetwork::lookup_cheat(std::string id)
+KadNode* KadNetwork::lookup_cheat(std::string id)
 {
-  return nodes_map[id];
+    return nodes_map[id];
 }
 
-/** 
+/**
  * find node nearest to specified routable
- * 
- * @param routable 
- * 
- * @return 
+ *
+ * @param routable
+ *
+ * @return
  */
-KadNode *
-KadNetwork::find_nearest_cheat(KadRoutable routable)
+KadNode* KadNetwork::find_nearest_cheat(KadRoutable routable)
 {
-  KadNode *nearest = NULL;
+    KadNode* nearest = NULL;
 
-  for (u_int i = 0;i < nodes.size();i++)
-    {
-      if (NULL == nearest)
-	nearest = nodes[i];
-      else
-	{
-	  CBigNum d1 = nodes[i]->distance_to(routable);
-	  CBigNum d2 = nearest->distance_to(routable);
-	  
-	  if (d1 < d2)
-	    nearest = nodes[i];
-	}
+    for (u_int i = 0; i < nodes.size(); i++) {
+        if (NULL == nearest)
+            nearest = nodes[i];
+        else {
+            CBigNum d1 = nodes[i]->distance_to(routable);
+            CBigNum d2 = nearest->distance_to(routable);
+
+            if (d1 < d2)
+                nearest = nodes[i];
+        }
     }
 
-  return nearest;
+    return nearest;
 }
 
-void
-KadNetwork::save(std::ostream& fout)
+void KadNetwork::save(std::ostream& fout)
 {
-  conf->save(fout);
-  for (u_int i = 0;i < conf->n_nodes;i++)
-    {
-      KadNode *node = nodes[i];
-      
-      fout << "node " << i << " " << node->get_id().ToString(16)  << "\n";
-      node->save(fout);
+    conf->save(fout);
+    for (u_int i = 0; i < conf->n_nodes; i++) {
+        KadNode* node = nodes[i];
+
+        fout << "node " << i << " " << node->get_id().ToString(16) << "\n";
+        node->save(fout);
     }
 }
 
-void
-KadNetwork::graphviz(std::ostream& fout)
+void KadNetwork::graphviz(std::ostream& fout)
 {
-  fout << "digraph G {\n";
-  fout << "  node [shape=record];\n";
-  fout << "  rankdir=TB;\n";
+    fout << "digraph G {\n";
+    fout << "  node [shape=record];\n";
+    fout << "  rankdir=TB;\n";
 
-  for (u_int i = 0;i < conf->n_nodes;i++)
-    {
-      KadNode *node = nodes[i];
-      
-      fout << "node_" << node->get_id().ToString(16) << " [color=blue, label=\"" << node->get_id().ToString(16) << "\"];\n";
-      node->graphviz(fout);
+    for (u_int i = 0; i < conf->n_nodes; i++) {
+        KadNode* node = nodes[i];
+
+        fout << "node_" << node->get_id().ToString(16)
+             << " [color=blue, label=\"" << node->get_id().ToString(16)
+             << "\"];\n";
+        node->graphviz(fout);
     }
 
-  fout << "}\n";
+    fout << "}\n";
 }

--- a/src/kad_node.cpp
+++ b/src/kad_node.cpp
@@ -1,545 +1,515 @@
 
 #include "kadsim.h"
 
-KadNode::KadNode(KadConf *conf, CBigNum id, std::string addr)
-  : KadRoutable(id, KAD_ROUTABLE_NODE)
+KadNode::KadNode(KadConf* conf, CBigNum id, std::string addr)
+    : KadRoutable(id, KAD_ROUTABLE_NODE)
 {
-  //std::cout << id1.ToString(16) << std::endl;
+    // std::cout << id1.ToString(16) << std::endl;
 
-  this->conf = conf;
-  this->id = id;
-  this->verbose = false;
-  this->addr = addr;
-  if (!addr.empty())
-    {
-      // FIXME use port
-      this->httpclient = new jsonrpc::HttpClient(addr);
-      this->kadc = new KadClient(*this->httpclient);
+    this->conf = conf;
+    this->id = id;
+    this->verbose = false;
+    this->addr = addr;
+    if (!addr.empty()) {
+        // FIXME use port
+        this->httpclient = new jsonrpc::HttpClient(addr);
+        this->kadc = new KadClient(*this->httpclient);
     }
 
-  // The passphrase of the account is the hex of the node ID.
-  this->eth_passphrase = id.ToString(16);
-  try
-    {
-      this->eth_account = conf->geth.personal_newAccount(eth_passphrase);
-      conf->geth.personal_unlockAccount(eth_account, eth_passphrase, 0);
-    }
-  catch (jsonrpc::JsonRpcException)
-    {
-      this->eth_account = "";
+    // The passphrase of the account is the hex of the node ID.
+    this->eth_passphrase = id.ToString(16);
+    try {
+        this->eth_account = conf->geth.personal_newAccount(eth_passphrase);
+        conf->geth.personal_unlockAccount(eth_account, eth_passphrase, 0);
+    } catch (jsonrpc::JsonRpcException) {
+        this->eth_account = "";
     }
 }
 
-KadNode::KadNode(KadConf *conf, CBigNum id)
-  : KadNode(conf, id, "")
-{
-}
+KadNode::KadNode(KadConf* conf, CBigNum id) : KadNode(conf, id, "") {}
 
-KadNode::~KadNode()
-{
-
-}
+KadNode::~KadNode() {}
 
 const std::string& KadNode::get_eth_account() const
 {
-  return eth_account;
+    return eth_account;
 }
 
-/** 
+/**
  * get the number of conns
- * 
- * 
- * @return 
+ *
+ *
+ * @return
  */
-int
-KadNode::get_n_conns()
+int KadNode::get_n_conns()
 {
-  int i, total;
+    int i, total;
 
-  total = 0;
-  for (i = 1; i < (conf->n_bits+1);i++)
-    total += buckets[i].size();
+    total = 0;
+    for (i = 1; i < (conf->n_bits + 1); i++)
+        total += buckets[i].size();
 
-  return total;
+    return total;
 }
 
-/** 
+/**
  * insert a node in the routing table
- * 
+ *
  * @param node the node address to add in the buckets
  * @param contacted_us true if node contacted us (thus is alive)
- * 
+ *
  * @return true if connection was added
  * @return false if connection was not added (e.g. because already present)
  */
-bool 
-KadNode::add_conn(KadNode *node,
-		  bool contacted_us)
+bool KadNode::add_conn(KadNode* node, bool contacted_us)
 {
-  //std::cout << get_id().ToString(16) << ": add_conn(" << node->get_id().ToString(16) << ")\n";
+    // std::cout << get_id().ToString(16) << ": add_conn(" <<
+    // node->get_id().ToString(16) << ")\n";
 
-  if (node->get_id() == get_id())
-    {
-      std::cout << "cannot add itself " << get_id().ToString(16) << std::endl;
-      return false;
+    if (node->get_id() == get_id()) {
+        std::cout << "cannot add itself " << get_id().ToString(16) << std::endl;
+        return false;
     }
 
-  CBigNum distance = distance_to(*node);
-  int bit_length = distance.bit_length();
+    CBigNum distance = distance_to(*node);
+    int bit_length = distance.bit_length();
 
-  //std::cout << "distance=" << distance.ToString(16) << " bit_length=" << bit_length << "\n";
+    // std::cout << "distance=" << distance.ToString(16) << " bit_length=" <<
+    // bit_length << "\n";
 
-  std::list<KadNode*> &list = buckets[bit_length];
-  std::list<KadNode*>::iterator it;
-  bool found = false;
-  for (it = list.begin();it != list.end();++it)
-    {
-      //std::cout << (*it).get_id().ToString(16) << "\n";
-      if ((*it)->get_id() == node->get_id())
-	{
-	  found = true;
-	  break ;
-	}
-    }
-  
-  if (found)
-    {
-      //std::cout << "node already in bucket\n";
-      if (contacted_us)
-	{
-	  //move item to the head
-	  list.splice(list.begin(), list, it);
-	  return false;
-	}
-      else
-	{
-	  //nothing to do
-	  return false;
-	}
-    }
-  
-  //add node in bucket
-  if (buckets[bit_length].size() < conf->k)
-    {
-      //std::cout << "added in bucket" << bit_length << " \n";
-      buckets[bit_length].push_back(node);
-      return true;
-    }
-  else
-    {
-      //std::cout << "bucket is full\n";
+    std::list<KadNode*>& list = buckets[bit_length];
+    std::list<KadNode*>::iterator it;
+    bool found = false;
+    for (it = list.begin(); it != list.end(); ++it) {
+        // std::cout << (*it).get_id().ToString(16) << "\n";
+        if ((*it)->get_id() == node->get_id()) {
+            found = true;
+            break;
+        }
     }
 
-  return false;
+    if (found) {
+        // std::cout << "node already in bucket\n";
+        if (contacted_us) {
+            // move item to the head
+            list.splice(list.begin(), list, it);
+            return false;
+        } else {
+            // nothing to do
+            return false;
+        }
+    }
+
+    // add node in bucket
+    if (buckets[bit_length].size() < conf->k) {
+        // std::cout << "added in bucket" << bit_length << " \n";
+        buckets[bit_length].push_back(node);
+        return true;
+    } else {
+        // std::cout << "bucket is full\n";
+    }
+
+    return false;
 }
 
-std::list<KadNode*> 
-KadNode::find_nearest_nodes(KadRoutable routable,
-                            int amount)
+std::list<KadNode*>
+KadNode::find_nearest_nodes(KadRoutable routable, int amount)
 {
-  if (!this->addr.empty())
-    {
-      Json::Value params;
-      params["to"] = routable.get_id().ToString();
-      params["amount"] = amount;
-      Json::Value val = this->kadc->find_nearest_nodes(params);
-      std::cout << val << "\n";
-      return std::list<KadNode*>();
-    }
-  else
-    {
-      return this->find_nearest_nodes_local(routable, amount);
+    if (!this->addr.empty()) {
+        Json::Value params;
+        params["to"] = routable.get_id().ToString();
+        params["amount"] = amount;
+        Json::Value val = this->kadc->find_nearest_nodes(params);
+        std::cout << val << "\n";
+        return std::list<KadNode*>();
+    } else {
+        return this->find_nearest_nodes_local(routable, amount);
     }
 }
 
-
-/** 
+/**
  * Find nodes closest to the given ID.
- * 
+ *
  * @param routable
  * @param amount
- * 
+ *
  * @return the list
  */
-std::list<KadNode*> 
-KadNode::find_nearest_nodes_local(KadRoutable routable,
-                                  int amount)
+std::list<KadNode*>
+KadNode::find_nearest_nodes_local(KadRoutable routable, int amount)
 {
-  CBigNum distance = distance_to(routable);
-  int bit_length = distance.bit_length();
+    CBigNum distance = distance_to(routable);
+    int bit_length = distance.bit_length();
 
-  int count = 0;
-  std::list<KadNode*> closest;
+    int count = 0;
+    std::list<KadNode*> closest;
 
-  //first look in the corresponding k-bucket
-  std::list<KadNode*> list = buckets[bit_length];
+    // first look in the corresponding k-bucket
+    std::list<KadNode*> list = buckets[bit_length];
 
-  list.sort(routable);
-  list.unique();
+    list.sort(routable);
+    list.unique();
 
-  if (verbose)
-    std::cout << "matching k-bucket is " << bit_length << "\n";
+    if (verbose)
+        std::cout << "matching k-bucket is " << bit_length << "\n";
 
-  if (!list.empty())
-    {
-      for (std::list<KadNode*>::iterator it = list.begin();it != list.end();++it)
-	{
-	  if (count >= amount)
-	    break ;
+    if (!list.empty()) {
+        for (std::list<KadNode*>::iterator it = list.begin(); it != list.end();
+             ++it) {
+            if (count >= amount)
+                break;
 
-	  if (verbose)
-	    std::cout << (*it)->get_id().ToString(16) << " distance=" << (*it)->distance_to(routable).ToString(16) << "\n";
+            if (verbose)
+                std::cout << (*it)->get_id().ToString(16) << " distance="
+                          << (*it)->distance_to(routable).ToString(16) << "\n";
 
-	  closest.push_back(*it);
-	  count++;
-	}
+            closest.push_back(*it);
+            count++;
+        }
     }
-  
-  if (count < amount)
-    {
-      std::list<KadNode*> all;
 
-      if (verbose)
-	std::cout << "other k-buckets\n";
+    if (count < amount) {
+        std::list<KadNode*> all;
 
-      //find remaining nearest nodes
-      for (int i = 1; i < (conf->n_bits+1);i++)
-	{
-	  if (bit_length != i)
-	    {
-	      std::list<KadNode*> &list = buckets[i];
-	      for (std::list<KadNode*>::iterator it = list.begin();it != list.end();++it)
-		{
-		  if (verbose)
-		    std::cout << "kbucket " << i << " " << (*it)->get_id().ToString(16) << " distance=" << (*it)->distance_to(routable).ToString(16) << "\n";
+        if (verbose)
+            std::cout << "other k-buckets\n";
 
-		  all.push_back(*it);
-		}
-	    }
-	}
+        // find remaining nearest nodes
+        for (int i = 1; i < (conf->n_bits + 1); i++) {
+            if (bit_length != i) {
+                std::list<KadNode*>& list = buckets[i];
+                for (std::list<KadNode*>::iterator it = list.begin();
+                     it != list.end();
+                     ++it) {
+                    if (verbose)
+                        std::cout << "kbucket " << i << " "
+                                  << (*it)->get_id().ToString(16)
+                                  << " distance="
+                                  << (*it)->distance_to(routable).ToString(16)
+                                  << "\n";
 
-      //sort answers
-      all.sort(routable);
-      all.unique();
+                    all.push_back(*it);
+                }
+            }
+        }
 
-      for (std::list<KadNode*>::iterator it = all.begin();it != all.end();++it)
-	{
-	  if (count >= amount)
-	    break ;
+        // sort answers
+        all.sort(routable);
+        all.unique();
 
-	  closest.push_back(*it);
-	  count++;
-	}
+        for (std::list<KadNode*>::iterator it = all.begin(); it != all.end();
+             ++it) {
+            if (count >= amount)
+                break;
+
+            closest.push_back(*it);
+            count++;
+        }
     }
-  
-  closest.sort(routable);
-  closest.unique();
 
-  return closest;
+    closest.sort(routable);
+    closest.unique();
+
+    return closest;
 }
 
-/** 
+/**
  * print a list of nodes and their distance to target
- * 
- * @param list 
- * @param routable 
+ *
+ * @param list
+ * @param routable
  */
-static void
-print_list(std::string comment,
-	   std::list<KadNode*> list,
-	   KadRoutable routable,
-	   std::map<KadNode*,bool> *queried)
+static void print_list(
+    std::string comment,
+    std::list<KadNode*> list,
+    KadRoutable routable,
+    std::map<KadNode*, bool>* queried)
 {
-  std::cout << "---" << comment << " size " << list.size() << "\n";
-  std::cout << "target " << routable.get_id().ToString(16) << "\n";
-  std::list<KadNode*>::iterator it;
-  for (it = list.begin();it != list.end();++it)
-    std::cout << "id " << (*it)->get_id().ToString(16)
-              << " eth_account " << (*it)->get_eth_account()
-              << " dist " << (*it)->distance_to(routable).ToString(16)
-              << " queried " << (*queried)[*it]
-              << "\n";
+    std::cout << "---" << comment << " size " << list.size() << "\n";
+    std::cout << "target " << routable.get_id().ToString(16) << "\n";
+    std::list<KadNode*>::iterator it;
+    for (it = list.begin(); it != list.end(); ++it)
+        std::cout << "id " << (*it)->get_id().ToString(16) << " eth_account "
+                  << (*it)->get_eth_account() << " dist "
+                  << (*it)->distance_to(routable).ToString(16) << " queried "
+                  << (*queried)[*it] << "\n";
 }
 
-/** 
+/**
  * Find the node closest to the given ID.
- * 
+ *
  * @param routable
- * 
+ *
  * @return the node
  */
-std::list<KadNode*>
-KadNode::lookup(KadRoutable routable)
+std::list<KadNode*> KadNode::lookup(KadRoutable routable)
 {
-  //pick our alpha starting nodes
-  std::list<KadNode*> starting_nodes;
-  std::list<KadNode*> answers;
-  std::map<KadNode*,bool> queried;
+    // pick our alpha starting nodes
+    std::list<KadNode*> starting_nodes;
+    std::list<KadNode*> answers;
+    std::map<KadNode*, bool> queried;
 
-  starting_nodes = find_nearest_nodes(routable, conf->alpha);
-  
-  if (verbose)
-    print_list("starting_nodes", starting_nodes, routable, &queried);
+    starting_nodes = find_nearest_nodes(routable, conf->alpha);
 
-  //send find_nodes
-  for (std::list<KadNode*>::iterator it = starting_nodes.begin();it != starting_nodes.end();++it)
-    {
-      std::list<KadNode*> answer = (*it)->find_nearest_nodes(routable, conf->k);
-      
-      //add to answers
-      for (std::list<KadNode*>::iterator it2 = answer.begin();it2 != answer.end();++it2)
-	{
-	  //remove oneself from the list
-	  if (get_id() != (*it2)->get_id())
-	    answers.push_back(*it2);
-	}
+    if (verbose)
+        print_list("starting_nodes", starting_nodes, routable, &queried);
+
+    // send find_nodes
+    for (std::list<KadNode*>::iterator it = starting_nodes.begin();
+         it != starting_nodes.end();
+         ++it) {
+        std::list<KadNode*> answer =
+            (*it)->find_nearest_nodes(routable, conf->k);
+
+        // add to answers
+        for (std::list<KadNode*>::iterator it2 = answer.begin();
+             it2 != answer.end();
+             ++it2) {
+            // remove oneself from the list
+            if (get_id() != (*it2)->get_id())
+                answers.push_back(*it2);
+        }
     }
 
-  //recursion
-  int round_nb = 0;
-  while (true)
-    {
-      if (verbose)
-	std::cout << "round=" << round_nb << "\n";
+    // recursion
+    int round_nb = 0;
+    while (true) {
+        if (verbose)
+            std::cout << "round=" << round_nb << "\n";
 
-      //sort answers
-      answers.sort(routable);
-      answers.unique();
+        // sort answers
+        answers.sort(routable);
+        answers.unique();
 
-      if (verbose)
-	print_list("answers", answers, routable, &queried);
-      
-      //take only k answers
-      std::list<KadNode*> k_answers;
-      u_int count = 0;
-      for (std::list<KadNode*>::iterator it = answers.begin();it != answers.end();++it)
-	{
-	  if (count >= conf->k)
-	    break ;
-	  
-	  k_answers.push_back(*it);
+        if (verbose)
+            print_list("answers", answers, routable, &queried);
 
-	  count++;
-	}
+        // take only k answers
+        std::list<KadNode*> k_answers;
+        u_int count = 0;
+        for (std::list<KadNode*>::iterator it = answers.begin();
+             it != answers.end();
+             ++it) {
+            if (count >= conf->k)
+                break;
 
-      if (verbose)
-	print_list("k_answers", k_answers, routable, &queried);
+            k_answers.push_back(*it);
 
-      std::list<KadNode*> round_answers;
+            count++;
+        }
 
-      std::list<KadNode*>::iterator it = k_answers.begin();
-      count = 0;
-      while (true)
-	{
-	  if (k_answers.end() == it)
-	    break ;
+        if (verbose)
+            print_list("k_answers", k_answers, routable, &queried);
 
-	  if (queried[*it])
-	    {
-	      it++;
-	      continue ;
-	    }
-	  
-	  if (count >= conf->alpha)
-	    break ;
+        std::list<KadNode*> round_answers;
 
-	  //std::cout << "querying " << (*it)->get_id().ToString(16) << "\n";
+        std::list<KadNode*>::iterator it = k_answers.begin();
+        count = 0;
+        while (true) {
+            if (k_answers.end() == it)
+                break;
 
-	  std::list<KadNode*> answer = (*it)->find_nearest_nodes(routable, conf->k);
-      
-	  //add to round_answers
-	  for (std::list<KadNode*>::iterator it2 = answer.begin();it2 != answer.end();++it2)
-	    {
-	      //std::cout << "found " << (*it2)->get_id().ToString(16) << "\n";
+            if (queried[*it]) {
+                it++;
+                continue;
+            }
 
-	      //remove oneself from the list
-	      if (get_id() != (*it2)->get_id())
-		round_answers.push_back(*it2);
-	    }
-      
-	  queried[*it] = true;
-	  
-	  count++;
-	  it++;
-	}
+            if (count >= conf->alpha)
+                break;
 
-      //break if we are done with the k_answers and nobody was queried
-      if (k_answers.end() == it && count == 0)
-	return k_answers;
+            // std::cout << "querying " << (*it)->get_id().ToString(16) << "\n";
 
-      //sort round answers
-      round_answers.sort(routable);
-      round_answers.unique();
+            std::list<KadNode*> answer =
+                (*it)->find_nearest_nodes(routable, conf->k);
 
-      if (verbose)
-	print_list("round_answers", round_answers, routable, &queried);
+            // add to round_answers
+            for (std::list<KadNode*>::iterator it2 = answer.begin();
+                 it2 != answer.end();
+                 ++it2) {
+                // std::cout << "found " << (*it2)->get_id().ToString(16) <<
+                // "\n";
 
-      //check if found closest
-      bool found_closest;
-      if (round_answers.empty() && k_answers.empty())
-	found_closest = false;
-      else if (!round_answers.empty() && k_answers.empty())
-	found_closest = true;
-      else if (round_answers.empty() && !k_answers.empty())
-	found_closest = false;
-      else
-	{
-	  CBigNum d1 = round_answers.front()->distance_to(routable);
-	  CBigNum d2 = k_answers.front()->distance_to(routable);
-	  found_closest = d1 < d2;
-	}
+                // remove oneself from the list
+                if (get_id() != (*it2)->get_id())
+                    round_answers.push_back(*it2);
+            }
 
-      if (verbose)
-	std::cout << "found_closest=" << found_closest << "\n";
+            queried[*it] = true;
 
-      if (!found_closest)
-	{
-	  //send queries to remaining k nodes
-	  while (true)
-	    {
-	      if (k_answers.end() == it)
-		break ;
-	      
-	      if (queried[*it])
-		{
-		  it++;
-		  continue ;
-		}
+            count++;
+            it++;
+        }
 
-	      std::list<KadNode*> answer = (*it)->find_nearest_nodes(routable, conf->k);
+        // break if we are done with the k_answers and nobody was queried
+        if (k_answers.end() == it && count == 0)
+            return k_answers;
 
-	      //add to answers
-	      for (std::list<KadNode*>::iterator it2 = answer.begin();it2 != answer.end();++it2)
-		{
-		  //remove oneself from the list
-		  if (get_id() != (*it2)->get_id())
-		    answers.push_back(*it2);
-		}
+        // sort round answers
+        round_answers.sort(routable);
+        round_answers.unique();
 
-	      queried[*it] = true;
-	      
-	      it++;
-	    }
+        if (verbose)
+            print_list("round_answers", round_answers, routable, &queried);
 
-	  round_nb++;
-	}
+        // check if found closest
+        bool found_closest;
+        if (round_answers.empty() && k_answers.empty())
+            found_closest = false;
+        else if (!round_answers.empty() && k_answers.empty())
+            found_closest = true;
+        else if (round_answers.empty() && !k_answers.empty())
+            found_closest = false;
+        else {
+            CBigNum d1 = round_answers.front()->distance_to(routable);
+            CBigNum d2 = k_answers.front()->distance_to(routable);
+            found_closest = d1 < d2;
+        }
+
+        if (verbose)
+            std::cout << "found_closest=" << found_closest << "\n";
+
+        if (!found_closest) {
+            // send queries to remaining k nodes
+            while (true) {
+                if (k_answers.end() == it)
+                    break;
+
+                if (queried[*it]) {
+                    it++;
+                    continue;
+                }
+
+                std::list<KadNode*> answer =
+                    (*it)->find_nearest_nodes(routable, conf->k);
+
+                // add to answers
+                for (std::list<KadNode*>::iterator it2 = answer.begin();
+                     it2 != answer.end();
+                     ++it2) {
+                    // remove oneself from the list
+                    if (get_id() != (*it2)->get_id())
+                        answers.push_back(*it2);
+                }
+
+                queried[*it] = true;
+
+                it++;
+            }
+
+            round_nb++;
+        }
     }
 
-  assert(0);
-  return std::list<KadNode*>();
+    assert(0);
+    return std::list<KadNode*>();
 }
 
-void
-KadNode::store(KadFile *file)
+void KadNode::store(KadFile* file)
 {
-  files.push_back(file);
+    files.push_back(file);
 }
 
-std::vector<KadFile*> 
-KadNode::get_files()
+std::vector<KadFile*> KadNode::get_files()
 {
-  return files;
+    return files;
 }
 
-void
-KadNode::show()
+void KadNode::show()
 {
-  std::cout << "id " << get_id().ToString(16) << "\n";
-  std::cout << "eth_account " << get_eth_account() << "\n";
-  std::cout << "n_conns " << get_n_conns() << "\n";
-  save(std::cout);
+    std::cout << "id " << get_id().ToString(16) << "\n";
+    std::cout << "eth_account " << get_eth_account() << "\n";
+    std::cout << "n_conns " << get_n_conns() << "\n";
+    save(std::cout);
 }
 
-void
-KadNode::set_verbose(int level)
+void KadNode::set_verbose(int level)
 {
-  this->verbose = level;
+    this->verbose = level;
 }
 
-void
-KadNode::save(std::ostream& fout)
+void KadNode::save(std::ostream& fout)
 {
-  for (int i = 1; i < (conf->n_bits+1);i++)
-    {
-      if (buckets[i].size() > 0)
-	{
-	  fout << "bucket " << i << "\n";
-	  std::list<KadNode*> &list = buckets[i];
-	  for (std::list<KadNode*>::iterator it = list.begin();it != list.end();++it)
-	    {
-	      fout << (*it)->get_id().ToString(16) << "\n";
-	    }
-	}
+    for (int i = 1; i < (conf->n_bits + 1); i++) {
+        if (buckets[i].size() > 0) {
+            fout << "bucket " << i << "\n";
+            std::list<KadNode*>& list = buckets[i];
+            for (std::list<KadNode*>::iterator it = list.begin();
+                 it != list.end();
+                 ++it) {
+                fout << (*it)->get_id().ToString(16) << "\n";
+            }
+        }
     }
 
-  fout << "files\n";
-  for (u_int i = 1; i < files.size();i++)
-    {
-      KadFile *file = files[i];
-      fout << file->get_id().ToString(16) << "\n";
+    fout << "files\n";
+    for (u_int i = 1; i < files.size(); i++) {
+        KadFile* file = files[i];
+        fout << file->get_id().ToString(16) << "\n";
     }
 }
 
-void
-KadNode::graphviz(std::ostream& fout)
+void KadNode::graphviz(std::ostream& fout)
 {
-  for (int i = 1; i < (conf->n_bits+1);i++)
-    {
-      if (buckets[i].size() > 0)
-	{
-	  std::list<KadNode*> &list = buckets[i];
-	  for (std::list<KadNode*>::iterator it = list.begin();it != list.end();++it)
-	    fout << "node_" << get_id().ToString(16) << " -> node_" << (*it)->get_id().ToString(16) << ";\n";
-	}
+    for (int i = 1; i < (conf->n_bits + 1); i++) {
+        if (buckets[i].size() > 0) {
+            std::list<KadNode*>& list = buckets[i];
+            for (std::list<KadNode*>::iterator it = list.begin();
+                 it != list.end();
+                 ++it)
+                fout << "node_" << get_id().ToString(16) << " -> node_"
+                     << (*it)->get_id().ToString(16) << ";\n";
+        }
     }
 }
 
 // TODO: factorize all of this
-void KadNode::buy_storage(const std::string &seller, uint64_t nb_bytes)
+void KadNode::buy_storage(const std::string& seller, uint64_t nb_bytes)
 {
-  // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
-  // web3.sha3("buyStorage(address,address,uint256)").substr(0, 8)
-  const std::string selector = "0x366e4d";
-  const std::string payload = selector + encode_address(eth_account)
-                                       + encode_address(seller)
-                                       + encode_uint256(nb_bytes);
+    // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+    // web3.sha3("buyStorage(address,address,uint256)").substr(0, 8)
+    const std::string selector = "0x366e4d";
+    const std::string payload = selector + encode_address(eth_account)
+                                + encode_address(seller)
+                                + encode_uint256(nb_bytes);
 
-  try {
-      call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-  } catch (jsonrpc::JsonRpcException exn) {
-      std::cerr << "cannot buy " << nb_bytes << "bytes from " << seller << ": " << exn.what() << '\n';
-  }
+    try {
+        call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
+    } catch (jsonrpc::JsonRpcException exn) {
+        std::cerr << "cannot buy " << nb_bytes << "bytes from " << seller
+                  << ": " << exn.what() << '\n';
+    }
 }
 
-void KadNode::put_bytes(const std::string &seller, uint64_t nb_bytes)
+void KadNode::put_bytes(const std::string& seller, uint64_t nb_bytes)
 {
-  // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
-  // web3.sha3("buyerPutBytes(address,address,uint256)").substr(0, 8)
-  const std::string selector = "0xed69a0";
-  const std::string payload = selector + encode_address(eth_account)
-                                       + encode_address(seller)
-                                       + encode_uint256(nb_bytes);
+    // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+    // web3.sha3("buyerPutBytes(address,address,uint256)").substr(0, 8)
+    const std::string selector = "0xed69a0";
+    const std::string payload = selector + encode_address(eth_account)
+                                + encode_address(seller)
+                                + encode_uint256(nb_bytes);
 
-  try {
-      call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-  } catch (jsonrpc::JsonRpcException exn) {
-      std::cerr << "cannot put " << nb_bytes << "bytes on storage of " << seller << ": " << exn.what() << '\n';
-  }
+    try {
+        call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
+    } catch (jsonrpc::JsonRpcException exn) {
+        std::cerr << "cannot put " << nb_bytes << "bytes on storage of "
+                  << seller << ": " << exn.what() << '\n';
+    }
 }
 
-
-void KadNode::get_bytes(const std::string &seller, uint64_t nb_bytes)
+void KadNode::get_bytes(const std::string& seller, uint64_t nb_bytes)
 {
-  // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
-  // web3.sha3("buyerGetBytes(address,address,uint256)").substr(0, 8)
-  const std::string selector = "0xdad071";
-  const std::string payload = selector + encode_address(eth_account)
-                                       + encode_address(seller)
-                                       + encode_uint256(nb_bytes);
+    // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+    // web3.sha3("buyerGetBytes(address,address,uint256)").substr(0, 8)
+    const std::string selector = "0xdad071";
+    const std::string payload = selector + encode_address(eth_account)
+                                + encode_address(seller)
+                                + encode_uint256(nb_bytes);
 
-  try {
-      call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-  } catch (jsonrpc::JsonRpcException exn) {
-      std::cerr << "cannot get " << nb_bytes << "bytes from storage of " << seller << ": " << exn.what() << '\n';
-  }
+    try {
+        call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
+    } catch (jsonrpc::JsonRpcException exn) {
+        std::cerr << "cannot get " << nb_bytes << "bytes from storage of "
+                  << seller << ": " << exn.what() << '\n';
+    }
 }

--- a/src/kad_routable.cpp
+++ b/src/kad_routable.cpp
@@ -1,4 +1,3 @@
-
 #include "kadsim.h"
 
 KadRoutable::KadRoutable(CBigNum id, enum KadRoutableType type)
@@ -19,9 +18,7 @@ CBigNum KadRoutable::distance_to(KadRoutable other) const
     return id ^ other.get_id();
 }
 
-/**
- * will sort from smallest distance to largest
- *
+/** Sort from smallest distance to largest.
  *
  * @return true if first is smaller than second
  */

--- a/src/kad_routable.cpp
+++ b/src/kad_routable.cpp
@@ -3,37 +3,32 @@
 
 KadRoutable::KadRoutable(CBigNum id, enum KadRoutableType type)
 {
-  this->id = id;
-  this->type = type;
+    this->id = id;
+    this->type = type;
 }
 
-KadRoutable::~KadRoutable()
+KadRoutable::~KadRoutable() {}
+
+CBigNum KadRoutable::get_id() const
 {
-
+    return id;
 }
 
-CBigNum
-KadRoutable::get_id() const
+CBigNum KadRoutable::distance_to(KadRoutable other) const
 {
-  return id;
+    return id ^ other.get_id();
 }
 
-CBigNum 
-KadRoutable::distance_to(KadRoutable other) const
-{
-  return id ^ other.get_id();
-}
-
-/** 
+/**
  * will sort from smallest distance to largest
- * 
- * 
+ *
+ *
  * @return true if first is smaller than second
  */
-bool
-KadRoutable::operator()(const KadRoutable * first, const KadRoutable * second) const
+bool KadRoutable::
+operator()(const KadRoutable* first, const KadRoutable* second) const
 {
-  CBigNum d1 = first->distance_to(*this);
-  CBigNum d2 = second->distance_to(*this);
-  return d1 < d2;
+    CBigNum d1 = first->distance_to(*this);
+    CBigNum d2 = second->distance_to(*this);
+    return d1 < d2;
 }

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -3,22 +3,22 @@
 
 // Most classes do not need copy or assignment constructors and should use this
 // macro to disable them.
-#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&);		   \
-  void operator=(const TypeName&)
+#define DISALLOW_COPY_AND_ASSIGN(TypeName)                                     \
+    TypeName(const TypeName&);                                                 \
+    void operator=(const TypeName&)
 
 // Address of the QuadIron contract on the blockchain.
-#define QUADIRON_CONTRACT_ADDR  "0x5e667a8D97fBDb2D3923a55b295DcB8f5985FB79"
+#define QUADIRON_CONTRACT_ADDR "0x5e667a8D97fBDb2D3923a55b295DcB8f5985FB79"
 
 #include <cstdint>
-#include <iostream>
-#include <stdlib.h>
-#include <assert.h>
-#include <map>
-#include <list>
-#include <vector>
 #include <fstream>
+#include <iostream>
+#include <list>
+#include <map>
+#include <vector>
+#include <assert.h>
 #include <getopt.h>
+#include <stdlib.h>
 
 #include <jsonrpccpp/client/connectors/httpclient.h>
 #include <netinet/in.h>
@@ -29,146 +29,143 @@
 #include "kadclient.h"
 #include "shell.h"
 
-class KadConf
-{
- public:
-  KadConf(int n_bits, int k, int alpha, int n_nodes,
-          const std::string &geth_addr,
-          const std::vector<std::string> bstraplist);
-  void save(std::ostream& fout);
-  int n_bits;
-  u_int k;
-  u_int alpha;
-  u_int n_nodes;
+class KadConf {
+  public:
+    KadConf(
+        int n_bits,
+        int k,
+        int alpha,
+        int n_nodes,
+        const std::string& geth_addr,
+        const std::vector<std::string> bstraplist);
+    void save(std::ostream& fout);
+    int n_bits;
+    u_int k;
+    u_int alpha;
+    u_int n_nodes;
 
-  jsonrpc::HttpClient httpclient;
-  GethClient geth;
-  std::vector<std::string> bstraplist;
+    jsonrpc::HttpClient httpclient;
+    GethClient geth;
+    std::vector<std::string> bstraplist;
 };
 
-enum KadRoutableType
-  {
+enum KadRoutableType {
     KAD_ROUTABLE_NODE,
     KAD_ROUTABLE_FILE,
-  };
+};
 
-class KadRoutable
-{
- public:
-  KadRoutable(CBigNum id, enum KadRoutableType);
-  ~KadRoutable();
+class KadRoutable {
+  public:
+    KadRoutable(CBigNum id, enum KadRoutableType);
+    ~KadRoutable();
 
-  CBigNum get_id() const;
-  bool is_remote();
-  KadRoutableType get_type();
-  CBigNum distance_to(KadRoutable other) const;
-  bool operator()(const KadRoutable *first, const KadRoutable *second) const;
+    CBigNum get_id() const;
+    bool is_remote();
+    KadRoutableType get_type();
+    CBigNum distance_to(KadRoutable other) const;
+    bool operator()(const KadRoutable* first, const KadRoutable* second) const;
 
- protected:
-
-  CBigNum id;
-  KadRoutableType type;
-  std::string addr; // remote peer IP address, or "" if local
-  jsonrpc::HttpClient *httpclient;
-  KadClient *kadc;
+  protected:
+    CBigNum id;
+    KadRoutableType type;
+    std::string addr; // remote peer IP address, or "" if local
+    jsonrpc::HttpClient* httpclient;
+    KadClient* kadc;
 };
 
 class KadNode;
 
-class KadFile : public KadRoutable
-{
- public:
-  KadFile(CBigNum id, KadNode *referencer);
-  ~KadFile();
-  KadNode *get_referencer();
+class KadFile : public KadRoutable {
+  public:
+    KadFile(CBigNum id, KadNode* referencer);
+    ~KadFile();
+    KadNode* get_referencer();
 
- private:
+  private:
+    KadNode* referencer;
 
-  KadNode *referencer;
-
-  //DISALLOW_COPY_AND_ASSIGN(KadFile);
+    // DISALLOW_COPY_AND_ASSIGN(KadFile);
 };
 
-class KadNode : public KadRoutable
-{
- public:
-  KadNode(KadConf *conf, CBigNum id);
-  KadNode(KadConf *conf, CBigNum id, std::string addr);
-  ~KadNode();
+class KadNode : public KadRoutable {
+  public:
+    KadNode(KadConf* conf, CBigNum id);
+    KadNode(KadConf* conf, CBigNum id, std::string addr);
+    ~KadNode();
 
-  int get_n_conns();
-  const std::string& get_eth_account() const;
-  bool add_conn(KadNode *node, bool contacted_us);
-  std::list<KadNode*> find_nearest_nodes(KadRoutable routable, int amount);
-  std::list<KadNode*> find_nearest_nodes_local(KadRoutable routable, int amount);
-  std::list<KadNode*> lookup(KadRoutable routable);
-  void show();
-  void set_verbose(int level);
-  void save(std::ostream& fout);
-  void store(KadFile *file);
-  std::vector<KadFile*> get_files();
-  void graphviz(std::ostream& fout);
+    int get_n_conns();
+    const std::string& get_eth_account() const;
+    bool add_conn(KadNode* node, bool contacted_us);
+    std::list<KadNode*> find_nearest_nodes(KadRoutable routable, int amount);
+    std::list<KadNode*>
+    find_nearest_nodes_local(KadRoutable routable, int amount);
+    std::list<KadNode*> lookup(KadRoutable routable);
+    void show();
+    void set_verbose(int level);
+    void save(std::ostream& fout);
+    void store(KadFile* file);
+    std::vector<KadFile*> get_files();
+    void graphviz(std::ostream& fout);
 
-  void buy_storage(const std::string &seller, uint64_t nb_bytes);
-  void put_bytes(const std::string &seller, uint64_t nb_bytes);
-  void get_bytes(const std::string &seller, uint64_t nb_bytes);
+    void buy_storage(const std::string& seller, uint64_t nb_bytes);
+    void put_bytes(const std::string& seller, uint64_t nb_bytes);
+    void get_bytes(const std::string& seller, uint64_t nb_bytes);
 
- private:
-  //DISALLOW_COPY_AND_ASSIGN(KadNode);
+  private:
+    // DISALLOW_COPY_AND_ASSIGN(KadNode);
 
-  KadConf *conf;
+    KadConf* conf;
 
-  typedef std::map<int,std::list<KadNode*> > tbucket;
-  tbucket buckets;
-  int verbose;
+    typedef std::map<int, std::list<KadNode*>> tbucket;
+    tbucket buckets;
+    int verbose;
 
-  std::vector<KadFile*> files;
-  std::string eth_passphrase;
-  std::string eth_account;
+    std::vector<KadFile*> files;
+    std::string eth_passphrase;
+    std::string eth_account;
 };
 
-typedef void (*tnode_callback_func)(KadNode *node, void *cb_arg);
-typedef void (*troutable_callback_func)(KadRoutable routable, void *cb_arg);
+typedef void (*tnode_callback_func)(KadNode* node, void* cb_arg);
+typedef void (*troutable_callback_func)(KadRoutable routable, void* cb_arg);
 
-class KadNetwork
-{
- public:
-  KadNetwork(KadConf *conf);
-  ~KadNetwork();
+class KadNetwork {
+  public:
+    KadNetwork(KadConf* conf);
+    ~KadNetwork();
 
-  void initialize_nodes(int n_initial_conn,
-                        std::vector<std::string> bstraplist);
-  void initialize_files(int n_files);
-  void rand_node(tnode_callback_func cb_func, void *cb_arg);
-  void rand_routable(troutable_callback_func cb_func, void *cb_arg);
-  KadNode *lookup_cheat(std::string id);
-  KadNode *find_nearest_cheat(KadRoutable routable);
-  void save(std::ostream& fout);
-  void graphviz(std::ostream& fout);
-  void check_files();
+    void
+    initialize_nodes(int n_initial_conn, std::vector<std::string> bstraplist);
+    void initialize_files(int n_files);
+    void rand_node(tnode_callback_func cb_func, void* cb_arg);
+    void rand_routable(troutable_callback_func cb_func, void* cb_arg);
+    KadNode* lookup_cheat(std::string id);
+    KadNode* find_nearest_cheat(KadRoutable routable);
+    void save(std::ostream& fout);
+    void graphviz(std::ostream& fout);
+    void check_files();
 
- private:
-  //DISALLOW_COPY_AND_ASSIGN(KadNetwork);
+  private:
+    // DISALLOW_COPY_AND_ASSIGN(KadNetwork);
 
-  KadConf *conf;
+    KadConf* conf;
 
-  std::vector<KadNode*> nodes;
-  std::map<std::string,KadNode*> nodes_map;
-  std::vector<KadFile*> files;
-
+    std::vector<KadNode*> nodes;
+    std::map<std::string, KadNode*> nodes_map;
+    std::vector<KadFile*> files;
 };
 
-extern struct cmd_def *cmd_defs[];
+extern struct cmd_def* cmd_defs[];
 
 // Encode an integer as an uint256 according to the Ethereum Contract ABI.
 // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
 std::string encode_uint256(uint64_t v);
 // Address are encoded as uint160
-std::string encode_address(const std::string &addr);
+std::string encode_address(const std::string& addr);
 
-void call_contract(GethClient &geth,
-                   const std::string &node_addr,
-                   const std::string &contract_addr,
-                   const std::string &payload);
+void call_contract(
+    GethClient& geth,
+    const std::string& node_addr,
+    const std::string& contract_addr,
+    const std::string& payload);
 
 #endif

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -10,16 +10,16 @@
 // Address of the QuadIron contract on the blockchain.
 #define QUADIRON_CONTRACT_ADDR "0x5e667a8D97fBDb2D3923a55b295DcB8f5985FB79"
 
+#include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <list>
 #include <map>
 #include <vector>
-#include <assert.h>
-#include <getopt.h>
-#include <stdlib.h>
 
+#include <getopt.h>
 #include <jsonrpccpp/client/connectors/httpclient.h>
 #include <netinet/in.h>
 
@@ -68,7 +68,7 @@ class KadRoutable {
   protected:
     CBigNum id;
     KadRoutableType type;
-    std::string addr; // remote peer IP address, or "" if local
+    std::string addr; // Remote peer IP address, or "" if local.
     jsonrpc::HttpClient* httpclient;
     KadClient* kadc;
 };
@@ -159,7 +159,7 @@ extern struct cmd_def* cmd_defs[];
 // Encode an integer as an uint256 according to the Ethereum Contract ABI.
 // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
 std::string encode_uint256(uint64_t v);
-// Address are encoded as uint160
+// Address are encoded as uint160.
 std::string encode_address(const std::string& addr);
 
 void call_contract(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,68 +1,71 @@
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 #include "kadsim.h"
 
 using namespace std;
 
-KadConf::KadConf(int n_bits, int k, int alpha, int n_nodes,
-                 const std::string&geth_addr,
-                 const std::vector<std::string> bstraplist)
-  : httpclient(geth_addr),
-    geth(httpclient),
-    bstraplist(bstraplist)
+KadConf::KadConf(
+    int n_bits,
+    int k,
+    int alpha,
+    int n_nodes,
+    const std::string& geth_addr,
+    const std::vector<std::string> bstraplist)
+    : httpclient(geth_addr), geth(httpclient), bstraplist(bstraplist)
 {
-  this->n_bits = n_bits;
-  this->k = k;
-  this->alpha = alpha;
-  this->n_nodes = n_nodes;
+    this->n_bits = n_bits;
+    this->k = k;
+    this->alpha = alpha;
+    this->n_nodes = n_nodes;
 }
 
-void
-KadConf::save(std::ostream& fout)
+void KadConf::save(std::ostream& fout)
 {
-  fout << "n_bits " << n_bits << "\n";
-  fout << "k " << k << "\n";
-  fout << "alpha " << alpha << "\n";
-  fout << "n_nodes " << n_nodes << "\n";
+    fout << "n_bits " << n_bits << "\n";
+    fout << "k " << k << "\n";
+    fout << "alpha " << alpha << "\n";
+    fout << "n_nodes " << n_nodes << "\n";
 }
 
-void call_contract(GethClient &geth,
-                   const std::string &node_addr,
-                   const std::string &contract_addr,
-                   const std::string &payload)
+void call_contract(
+    GethClient& geth,
+    const std::string& node_addr,
+    const std::string& contract_addr,
+    const std::string& payload)
 
 {
-  Json::Value params;
+    Json::Value params;
 
-  params["from"] = node_addr;
-  params["to"]   = contract_addr;
-  params["data"] = payload;
+    params["from"] = node_addr;
+    params["to"] = contract_addr;
+    params["data"] = payload;
 
-  const std::string tx_hash = geth.eth_sendTransaction(params);
-  std::cout << "tx_hash: " << tx_hash << '\n';
+    const std::string tx_hash = geth.eth_sendTransaction(params);
+    std::cout << "tx_hash: " << tx_hash << '\n';
 
-  // FIXME: busy way is ugly.
-  while (true) {
-      try {
-          const Json::Value receipt = geth.eth_getTransactionReceipt(tx_hash);
-          std::cout << "result: " << receipt.toStyledString() << '\n';
-          // TODO: we should probably return a bool to the caller, or raise…
-          if (receipt["status"] == "0x0") {
-              std::cout << "transaction failed\n";
-          } else {
-              std::cout << "transaction successed: " << receipt["status"] << '\n';
-          }
-          return;
-      } catch (jsonrpc::JsonRpcException exn) {
-          if (exn.GetCode() == -32000) {
-              continue;  // Transaction is pending…
-          } else {
-              fprintf(stderr, "error: %s\n", exn.what());
-              throw;
-          }
-      }
-  }
+    // FIXME: busy way is ugly.
+    while (true) {
+        try {
+            const Json::Value receipt = geth.eth_getTransactionReceipt(tx_hash);
+            std::cout << "result: " << receipt.toStyledString() << '\n';
+            // TODO: we should probably return a bool to the caller, or raise…
+            if (receipt["status"] == "0x0") {
+                std::cout << "transaction failed\n";
+            } else {
+                std::cout << "transaction successed: " << receipt["status"]
+                          << '\n';
+            }
+            return;
+        } catch (jsonrpc::JsonRpcException exn) {
+            if (exn.GetCode() == -32000) {
+                continue; // Transaction is pending…
+            } else {
+                fprintf(stderr, "error: %s\n", exn.what());
+                throw;
+            }
+        }
+    }
 }
 
 // From https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI:
@@ -77,7 +80,7 @@ std::string encode_uint256(uint64_t v)
     return oss.str();
 }
 
-std::string encode_address(const std::string &addr)
+std::string encode_address(const std::string& addr)
 {
     std::ostringstream oss;
     // Skip the leading 0x, pad for 160 bytes.
@@ -85,129 +88,125 @@ std::string encode_address(const std::string &addr)
     return oss.str();
 }
 
-void
-usage()
+void usage()
 {
-  std::cerr << "usage: kadsim\n";
-  std::cerr << "\t-b\tn_bits\n";
-  std::cerr << "\t-k\tKademlia K parameter\n";
-  std::cerr << "\t-a\tKademlia alpha parameter\n";
-  std::cerr << "\t-n\tnumber of nodes\n";
-  std::cerr << "\t-c\tinitial number of connections per node\n";
-  std::cerr << "\t-g\tgeth RPC server address\n";
-  std::cerr << "\t-B\tbootstrap list (comma-separated list of IPs)\n";
-  std::cerr << "\t-N\tnumber of files\n";
-  std::cerr << "\t-S\trandom seed\n";
-  exit(1);
+    std::cerr << "usage: kadsim\n";
+    std::cerr << "\t-b\tn_bits\n";
+    std::cerr << "\t-k\tKademlia K parameter\n";
+    std::cerr << "\t-a\tKademlia alpha parameter\n";
+    std::cerr << "\t-n\tnumber of nodes\n";
+    std::cerr << "\t-c\tinitial number of connections per node\n";
+    std::cerr << "\t-g\tgeth RPC server address\n";
+    std::cerr << "\t-B\tbootstrap list (comma-separated list of IPs)\n";
+    std::cerr << "\t-N\tnumber of files\n";
+    std::cerr << "\t-S\trandom seed\n";
+    exit(1);
 }
 
-void
-parse_error()
+void parse_error()
 {
-  std::cerr << "parse error\n";
-  exit(1);
+    std::cerr << "parse error\n";
+    exit(1);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-  int c;
-  int n_bits = 64;
-  int k = 20;
-  int alpha = 3;
-  int n_nodes = 1500;
-  int n_init_conn = 100;
-  int n_files = 5000;
-  int rand_seed = 0;
-  char *fname = NULL;
-  std::string geth_addr = "localhost:8545";
-  std::vector<std::string> bstraplist;
-     
-  opterr = 0;
-     
-  while ((c = getopt (argc, argv, "b:k:a:n:c:g:B:S:f:N:")) != -1)
-    {
-      switch (c)
-	{
-	case 'b':
-	  n_bits = atoi(optarg);
-	  break;
-	case 'k':
-	  k = atoi(optarg);
-	  break;
-	case 'a':
-	  alpha = atoi(optarg);
-	  break;
-	case 'n':
-	  n_nodes = atoi(optarg);
-	  break;
-	case 'c':
-	  n_init_conn = atoi(optarg);
-	  break;
-	case 'g':
-	  geth_addr = optarg;
-	  break;
-        case 'B':
-          {
-            char *bstraplist_dup = strdup(optarg);
-            char *bstrap;
-            while (NULL != (bstrap = strtok(bstraplist_dup, ",")))
-              {
+    int c;
+    int n_bits = 64;
+    int k = 20;
+    int alpha = 3;
+    int n_nodes = 1500;
+    int n_init_conn = 100;
+    int n_files = 5000;
+    int rand_seed = 0;
+    char* fname = NULL;
+    std::string geth_addr = "localhost:8545";
+    std::vector<std::string> bstraplist;
+
+    opterr = 0;
+
+    while ((c = getopt(argc, argv, "b:k:a:n:c:g:B:S:f:N:")) != -1) {
+        switch (c) {
+        case 'b':
+            n_bits = atoi(optarg);
+            break;
+        case 'k':
+            k = atoi(optarg);
+            break;
+        case 'a':
+            alpha = atoi(optarg);
+            break;
+        case 'n':
+            n_nodes = atoi(optarg);
+            break;
+        case 'c':
+            n_init_conn = atoi(optarg);
+            break;
+        case 'g':
+            geth_addr = optarg;
+            break;
+        case 'B': {
+            char* bstraplist_dup = strdup(optarg);
+            char* bstrap;
+            while (NULL != (bstrap = strtok(bstraplist_dup, ","))) {
                 bstraplist_dup = NULL;
                 bstraplist.push_back(bstrap);
-              }
+            }
             break;
-          }
-	case 'S':
-	  rand_seed = atoi(optarg);
-	  break ;
-	case 'f':
-	  fname = strdup(optarg);
-	  break ;
-	case 'N':
-	  n_files = atoi(optarg);
-	  break ;
-	case '?':
-	default:
-	  usage();
-	}
+        }
+        case 'S':
+            rand_seed = atoi(optarg);
+            break;
+        case 'f':
+            fname = strdup(optarg);
+            break;
+        case 'N':
+            n_files = atoi(optarg);
+            break;
+        case '?':
+        default:
+            usage();
+        }
     }
 
-  if (fname)
-    {
-      std::ifstream fin(fname);
-      if (!fin.is_open())
-	{
-	  std::cerr << "unable to open " << fname << "\n";
-	  exit(1);
-	}
+    if (fname) {
+        std::ifstream fin(fname);
+        if (!fin.is_open()) {
+            std::cerr << "unable to open " << fname << "\n";
+            exit(1);
+        }
 
-      char buf[256], *p;
-#define GETLINE() \
-      fin.getline(buf, sizeof (buf));	  \
-      if (NULL == (p = rindex(buf, ' '))) \
-	parse_error();			  \
-      p++;
-      GETLINE(); n_bits = atoi(p);
-      GETLINE(); k = atoi(p);
-      GETLINE(); alpha = atoi(p);
-      GETLINE(); n_nodes = atoi(p);
+        char buf[256], *p;
+#define GETLINE()                                                              \
+    fin.getline(buf, sizeof(buf));                                             \
+    if (NULL == (p = rindex(buf, ' ')))                                        \
+        parse_error();                                                         \
+    p++;
+        GETLINE();
+        n_bits = atoi(p);
+        GETLINE();
+        k = atoi(p);
+        GETLINE();
+        alpha = atoi(p);
+        GETLINE();
+        n_nodes = atoi(p);
     }
 
-  KadConf conf(n_bits, k, alpha, n_nodes, geth_addr, bstraplist);
-  //conf.save(std::cout);
-  KadNetwork network(&conf);
-  Shell shell;
+    KadConf conf(n_bits, k, alpha, n_nodes, geth_addr, bstraplist);
+    // conf.save(std::cout);
+    KadNetwork network(&conf);
+    Shell shell;
 
-  srand(rand_seed);
+    srand(rand_seed);
 
-  network.initialize_nodes(n_init_conn, bstraplist);
-  network.initialize_files(n_files);
-  network.check_files();
+    network.initialize_nodes(n_init_conn, bstraplist);
+    network.initialize_files(n_files);
+    network.check_files();
 
-  shell.set_cmds(cmd_defs);
-  shell.set_handle(&network);
-  shell.set_prompt("kadsim> ");
-  shell.loop();
+    shell.set_cmds(cmd_defs);
+    shell.set_handle(&network);
+    shell.set_prompt("kadsim> ");
+    shell.loop();
 
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,6 @@
 
 #include "kadsim.h"
 
-using namespace std;
-
 KadConf::KadConf(
     int n_bits,
     int k,
@@ -33,7 +31,6 @@ void call_contract(
     const std::string& node_addr,
     const std::string& contract_addr,
     const std::string& payload)
-
 {
     Json::Value params;
 

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -1,197 +1,166 @@
 #include "shell.h"
 
 static char sargmem[SHELL_MAX_ARGV][SHELL_MAX_ARG_LEN];
-static char *sargv[SHELL_MAX_ARGV + 1];
-static int  sargc;
+static char* sargv[SHELL_MAX_ARGV + 1];
+static int sargc;
 
 /**/
 
-const char *shell_err_strings[] =
-  {
+const char* shell_err_strings[] = {
     "No error",
     "too many args",
     "argument is too long",
     "double quote error",
     NULL,
-  };
+};
 
-const char *
-shell_error_str(enum shell_error err)
+const char* shell_error_str(enum shell_error err)
 {
-  return (shell_err_strings[err]);
+    return (shell_err_strings[err]);
 }
 
-static struct cmd_def **g_cmd_defs = NULL;
+static struct cmd_def** g_cmd_defs = NULL;
 
 /**
  * for completion
  *
  * @param defs
  */
-void
-shell_install_cmd_defs(struct cmd_def **defs)
+void shell_install_cmd_defs(struct cmd_def** defs)
 {
-  g_cmd_defs = defs;
+    g_cmd_defs = defs;
 }
 
-static char *
-command_generator(const char *text,
-                  int state)
+static char* command_generator(const char* text, int state)
 {
-  static int list_index, len;
-  const char *name;
-  struct cmd_def *def;
+    static int list_index, len;
+    const char* name;
+    struct cmd_def* def;
 
-  if (!state)
-    {
-      list_index = 0;
-      len = strlen (text);
+    if (!state) {
+        list_index = 0;
+        len = strlen(text);
     }
 
-  while (g_cmd_defs[list_index])
-    {
-      def = g_cmd_defs[list_index];
-      name = def->name;
+    while (g_cmd_defs[list_index]) {
+        def = g_cmd_defs[list_index];
+        name = def->name;
 
-      list_index++;
+        list_index++;
 
-      if (strncmp(name, text, len) == 0)
-	{
-	  char *nptr = strdup(name);
-	  assert(NULL != nptr);
-	  return nptr;
-	}
+        if (strncmp(name, text, len) == 0) {
+            char* nptr = strdup(name);
+            assert(NULL != nptr);
+            return nptr;
+        }
     }
 
-  /* If no names matched, then return NULL. */
-  return ((char *) NULL);
+    /* If no names matched, then return NULL. */
+    return ((char*)NULL);
 }
 
-char **
-shell_completion(const char *text,
-                 int start,
-                 int end)
+char** shell_completion(const char* text, int start, int end)
 {
-  char **matches;
+    char** matches;
 
-  if (NULL == g_cmd_defs)
-    return NULL;
+    if (NULL == g_cmd_defs)
+        return NULL;
 
-  matches = (char **)NULL;
+    matches = (char**)NULL;
 
-  if (start == 0)
-    matches = rl_completion_matches(text, command_generator);
+    if (start == 0)
+        matches = rl_completion_matches(text, command_generator);
 
-  return (matches);
+    return (matches);
 }
 
 bool Shell::class_initialized = false;
 
 Shell::Shell()
 {
-  if (!Shell::class_initialized)
-    {
-      rl_attempted_completion_function = shell_completion;
-      Shell::class_initialized = true;
+    if (!Shell::class_initialized) {
+        rl_attempted_completion_function = shell_completion;
+        Shell::class_initialized = true;
     }
 
-  defs = NULL;
-  handle = NULL;
-  handle2 = NULL;
-  prompt = NULL;
+    defs = NULL;
+    handle = NULL;
+    handle2 = NULL;
+    prompt = NULL;
 }
 
-int
-Shell::do_cmd(struct cmd_def **defs,
-	      int argc,
-	      char **argv)
+int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
 {
-  struct cmd_def *def, *tmp;
-  int ret, len, found;
-  char *p;
-  int i;
+    struct cmd_def *def, *tmp;
+    int ret, len, found;
+    char* p;
+    int i;
 
-  if (argc == 0)
-    return SHELL_CONT;
+    if (argc == 0)
+        return SHELL_CONT;
 
-  if ('!' == argv[0][0])
-    {
-      pid_t pid;
+    if ('!' == argv[0][0]) {
+        pid_t pid;
 
-      pid = fork();
-      if (-1 == pid)
-        {
-          perror("fork");
-          return SHELL_CONT;
+        pid = fork();
+        if (-1 == pid) {
+            perror("fork");
+            return SHELL_CONT;
         }
-      if (0 == pid)
-        {
-          argv[0]++;
+        if (0 == pid) {
+            argv[0]++;
 
-          ret = execvp(argv[0], argv);
-          if (-1 == ret)
-            {
-              perror("execvp");
-              exit(1);
+            ret = execvp(argv[0], argv);
+            if (-1 == ret) {
+                perror("execvp");
+                exit(1);
             }
-        }
-      else
-        {
+        } else {
         retry:
-          ret = wait(0);
-          if (-1 == ret)
-            {
-              if (EINTR == errno)
-                goto retry;
-              else
-                {
-                  perror("wait");
-                  exit(1);
+            ret = wait(0);
+            if (-1 == ret) {
+                if (EINTR == errno)
+                    goto retry;
+                else {
+                    perror("wait");
+                    exit(1);
                 }
             }
         }
-      return SHELL_CONT;
+        return SHELL_CONT;
+    } else if (NULL != (p = index(argv[0], '='))) {
+        *p++ = 0;
+        // var_set(argv[0], p, VAR_CMD_SET, NULL);
+        return SHELL_CONT;
     }
-  else if (NULL != (p = index(argv[0], '=')))
-    {
-      *p++ = 0;
-      //var_set(argv[0], p, VAR_CMD_SET, NULL);
-      return SHELL_CONT;
-    }
-  len = strlen(argv[0]);
+    len = strlen(argv[0]);
 
-  def = NULL;
-  found = 0;
-  for (i = 0;defs[i];i++)
-    {
-      tmp = defs[i];
-      //printf("'%s' '%s'\n", argv[0], tmp->name);
-      if (!strcmp(argv[0], tmp->name))
-        {
-          found = 1;
-          def = tmp;
-          break ;
-        }
-      else if (!strncmp(argv[0], tmp->name, len))
-	{
-          if (1 == found)
-            {
-              fprintf(stderr, "ambiguous command: %s\n", argv[0]);
-              return SHELL_CONT;
+    def = NULL;
+    found = 0;
+    for (i = 0; defs[i]; i++) {
+        tmp = defs[i];
+        // printf("'%s' '%s'\n", argv[0], tmp->name);
+        if (!strcmp(argv[0], tmp->name)) {
+            found = 1;
+            def = tmp;
+            break;
+        } else if (!strncmp(argv[0], tmp->name, len)) {
+            if (1 == found) {
+                fprintf(stderr, "ambiguous command: %s\n", argv[0]);
+                return SHELL_CONT;
             }
-          found = 1;
-          def = tmp;
-	}
+            found = 1;
+            def = tmp;
+        }
     }
 
-  if (0 == found)
-    {
-      fprintf(stderr, "cmd %s: not found\n", argv[0]);
-      return SHELL_CONT;
+    if (0 == found) {
+        fprintf(stderr, "cmd %s: not found\n", argv[0]);
+        return SHELL_CONT;
     }
 
-  ret = def->func(this, argc, argv);
-  return ret;
+    ret = def->func(this, argc, argv);
+    return ret;
 }
 
 /**
@@ -205,212 +174,178 @@ Shell::do_cmd(struct cmd_def **defs,
  *
  * @return 0 if OK, -1 on failure
  */
-int
-Shell::parse(struct cmd_def **defs,
-	     char *str,
-	     enum shell_error *errp)
+int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
 {
-  int pos, skip_ws, comment, dblquote, ret;
-  char c;
+    int pos, skip_ws, comment, dblquote, ret;
+    char c;
 
-  sargc = pos = 0;
-  comment = dblquote = 0;
-  skip_ws = 1;
+    sargc = pos = 0;
+    comment = dblquote = 0;
+    skip_ws = 1;
 
-  while (1)
-    {
-      c = *str;
+    while (1) {
+        c = *str;
 
-      switch (c)
-        {
+        switch (c) {
         case '"':
-          if (dblquote)
-            {
-              dblquote = 0;
-              if (0 == pos)
-                {
-                  skip_ws = 0;
-                  c = 0;
-                  goto store_it;
+            if (dblquote) {
+                dblquote = 0;
+                if (0 == pos) {
+                    skip_ws = 0;
+                    c = 0;
+                    goto store_it;
                 }
-            }
-          else
-            dblquote = 1;
-          break ;
+            } else
+                dblquote = 1;
+            break;
 
         case '#':
-          comment = 1;
-          break ;
+            comment = 1;
+            break;
 
-	case '\0':
+        case '\0':
         case ';':
         case '\n':
 
-          if (c == ';' && 1 == dblquote)
-            {
-              skip_ws = 0;
-              goto store_it;
+            if (c == ';' && 1 == dblquote) {
+                skip_ws = 0;
+                goto store_it;
             }
 
-	  sargv[sargc] = &sargmem[sargc][0];
+            sargv[sargc] = &sargmem[sargc][0];
 
-	  if (!skip_ws)
-	    sargc++;
+            if (!skip_ws)
+                sargc++;
 
-	  sargv[sargc] = NULL;
+            sargv[sargc] = NULL;
 
-	  if (dblquote)
-	    {
-	      if (errp)
-		*errp = SHELL_ERROR_DBL_QUOTE;
-	      return -1;
-	    }
+            if (dblquote) {
+                if (errp)
+                    *errp = SHELL_ERROR_DBL_QUOTE;
+                return -1;
+            }
 
-	  if ((ret = do_cmd(defs, sargc, sargv)) != SHELL_CONT)
-	    return ret;
+            if ((ret = do_cmd(defs, sargc, sargv)) != SHELL_CONT)
+                return ret;
 
-          memset(sargmem, 0, sizeof (sargmem));
+            memset(sargmem, 0, sizeof(sargmem));
 
-	  sargc = pos = 0;
-	  comment = dblquote = 0;
-	  skip_ws = 1;
+            sargc = pos = 0;
+            comment = dblquote = 0;
+            skip_ws = 1;
 
-	  if (c == '\0')
-	    return 0;
+            if (c == '\0')
+                return 0;
 
-          break ;
+            break;
 
         case ' ':
         case '\t':
 
-          if (comment)
-            break ;
+            if (comment)
+                break;
 
-          if (dblquote)
-            {
-              skip_ws = 0;
-              goto store_it;
+            if (dblquote) {
+                skip_ws = 0;
+                goto store_it;
             }
 
-          if (!skip_ws)
-            {
-              if ((sargc + 1) < SHELL_MAX_ARGV)
-                {
-                  sargv[sargc] = &sargmem[sargc][0];
-                  sargc++;
-                  sargv[sargc] = NULL;
-                  pos = 0;
+            if (!skip_ws) {
+                if ((sargc + 1) < SHELL_MAX_ARGV) {
+                    sargv[sargc] = &sargmem[sargc][0];
+                    sargc++;
+                    sargv[sargc] = NULL;
+                    pos = 0;
+                } else {
+                    if (errp)
+                        *errp = SHELL_ERROR_TOO_MANY_ARGS;
+                    return -1;
                 }
-              else
-                {
-                  if (errp)
-		    *errp = SHELL_ERROR_TOO_MANY_ARGS;
-		  return -1;
-                }
-              skip_ws = 1;
+                skip_ws = 1;
             }
-          break ;
+            break;
 
         default:
 
-          if (comment)
-            break ;
-          skip_ws = 0;
+            if (comment)
+                break;
+            skip_ws = 0;
 
         store_it:
-          if ((pos + 1) < SHELL_MAX_ARG_LEN)
-            {
-              sargmem[sargc][pos++] = c;
-              sargmem[sargc][pos] = 0;
-            }
-          else
-            {
-              if (errp)
-		*errp = SHELL_ERROR_ARG_TOO_LONG;
-	      return -1;
+            if ((pos + 1) < SHELL_MAX_ARG_LEN) {
+                sargmem[sargc][pos++] = c;
+                sargmem[sargc][pos] = 0;
+            } else {
+                if (errp)
+                    *errp = SHELL_ERROR_ARG_TOO_LONG;
+                return -1;
             }
         }
-      str++;
+        str++;
     }
 
-  return 0;
+    return 0;
 }
 
-void
-Shell::set_cmds(struct cmd_def **defs)
+void Shell::set_cmds(struct cmd_def** defs)
 {
-  g_cmd_defs = this->defs = defs;
+    g_cmd_defs = this->defs = defs;
 }
 
-void
-Shell::set_handle(void *handle)
+void Shell::set_handle(void* handle)
 {
-  this->handle = handle;
+    this->handle = handle;
 }
 
-void
-Shell::set_handle2(void *handle)
+void Shell::set_handle2(void* handle)
 {
-  this->handle2 = handle;
+    this->handle2 = handle;
 }
 
-void *
-Shell::get_handle()
+void* Shell::get_handle()
 {
-  return handle;
+    return handle;
 }
 
-void *
-Shell::get_handle2()
+void* Shell::get_handle2()
 {
-  return handle2;
+    return handle2;
 }
 
-void
-Shell::set_prompt(const char *prompt)
+void Shell::set_prompt(const char* prompt)
 {
-  char *nprompt = strdup(prompt);
-  if (NULL == nprompt)
-    {
-      perror("strdup");
-      exit(1);
+    char* nprompt = strdup(prompt);
+    if (NULL == nprompt) {
+        perror("strdup");
+        exit(1);
     }
-  free(this->prompt);
-  this->prompt = nprompt;
+    free(this->prompt);
+    this->prompt = nprompt;
 }
 
-void
-Shell::loop()
+void Shell::loop()
 {
-  using_history();
+    using_history();
 
-  while (1)
-    {
-      char *line = NULL;
+    while (1) {
+        char* line = NULL;
 
-      if ((line = readline(prompt)))
-        {
-          enum shell_error shell_err;
-          int ret;
+        if ((line = readline(prompt))) {
+            enum shell_error shell_err;
+            int ret;
 
-          ret = parse(defs, line, &shell_err);
-          if (ret == SHELL_EPARSE)
-            {
-              fprintf(stderr,
-                      "parsing: %s\n", shell_error_str(shell_err));
+            ret = parse(defs, line, &shell_err);
+            if (ret == SHELL_EPARSE) {
+                fprintf(stderr, "parsing: %s\n", shell_error_str(shell_err));
+            } else if (ret == SHELL_RETURN) {
+                return;
             }
-          else if (ret == SHELL_RETURN)
-            {
-              return ;
-            }
-          if (strcmp(line, ""))
-            add_history(line);
-          free(line);
-        }
-      else
-        {
-          fprintf(stderr, "quit\n");
-          return ;
+            if (strcmp(line, ""))
+                add_history(line);
+            free(line);
+        } else {
+            fprintf(stderr, "quit\n");
+            return;
         }
     }
 }

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -4,8 +4,6 @@ static char sargmem[SHELL_MAX_ARGV][SHELL_MAX_ARG_LEN];
 static char* sargv[SHELL_MAX_ARGV + 1];
 static int sargc;
 
-/**/
-
 const char* shell_err_strings[] = {
     "No error",
     "too many args",
@@ -21,8 +19,7 @@ const char* shell_error_str(enum shell_error err)
 
 static struct cmd_def** g_cmd_defs = NULL;
 
-/**
- * for completion
+/** For completion.
  *
  * @param defs
  */
@@ -130,7 +127,6 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
         return SHELL_CONT;
     } else if (NULL != (p = index(argv[0], '='))) {
         *p++ = 0;
-        // var_set(argv[0], p, VAR_CMD_SET, NULL);
         return SHELL_CONT;
     }
     len = strlen(argv[0]);
@@ -139,7 +135,6 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
     found = 0;
     for (i = 0; defs[i]; i++) {
         tmp = defs[i];
-        // printf("'%s' '%s'\n", argv[0], tmp->name);
         if (!strcmp(argv[0], tmp->name)) {
             found = 1;
             def = tmp;
@@ -163,10 +158,12 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
     return ret;
 }
 
-/**
- * parse a string into multiple commands. everything is done
- * static. understands comments (sharp sign), double quotes, semicolon.
- * ignore whitspaces
+/** Parse a string into multiple commands.
+ *
+ * Everything is done static.
+ *
+ * Understands comments (sharp sign), double quotes, semicolon. ignore
+ * whitspaces
  *
  * @param str the input string
  * @param cmd the callback

--- a/src/shell.h
+++ b/src/shell.h
@@ -1,10 +1,11 @@
 #ifndef __SHELL_H__
 #define __SHELL_H__ 1
 
+#include <cassert>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <assert.h>
+
 #include <sys/wait.h>
 #include <unistd.h>
 #if defined(HAVE_READLINE)

--- a/src/shell.h
+++ b/src/shell.h
@@ -1,65 +1,62 @@
 #ifndef __SHELL_H__
-#define __SHELL_H__	1
+#define __SHELL_H__ 1
 
-#include <unistd.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 #include <assert.h>
 #include <sys/wait.h>
-#include <cstring>
-#include <cstdlib>
-#include <cerrno>
-#if defined (HAVE_READLINE)
-# include <readline/readline.h>
-# include <readline/history.h>
+#include <unistd.h>
+#if defined(HAVE_READLINE)
+#include <readline/history.h>
+#include <readline/readline.h>
 #else
-# include <editline/readline.h>
+#include <editline/readline.h>
 #endif /* HAVE_READLINE */
 
-#define SHELL_MAX_ARG_LEN	128
-#define SHELL_MAX_ARGV		16
+#define SHELL_MAX_ARG_LEN 128
+#define SHELL_MAX_ARGV 16
 
-enum shell_error
-  {
+enum shell_error {
     SHELL_ERROR_NONE,
     SHELL_ERROR_TOO_MANY_ARGS,
     SHELL_ERROR_ARG_TOO_LONG,
     SHELL_ERROR_DBL_QUOTE,
-  };
+};
 
-#define SHELL_CONT	0
-#define SHELL_EPARSE	-1
-#define SHELL_RETURN	-2
+#define SHELL_CONT 0
+#define SHELL_EPARSE -1
+#define SHELL_RETURN -2
 
 class Shell;
 
-struct cmd_def
-{
-  const char *name;
-  const char *purpose;
-  int   (*func)(Shell *shell, int argc, char **argv);
+struct cmd_def {
+    const char* name;
+    const char* purpose;
+    int (*func)(Shell* shell, int argc, char** argv);
 };
 
-class Shell
-{
- public:
-  Shell();
+class Shell {
+  public:
+    Shell();
 
-  void set_cmds(struct cmd_def **defs);
-  void set_handle(void *hande);
-  void set_handle2(void *hande);
-  void set_prompt(const char *prompt);
-  void *get_handle();
-  void *get_handle2();
-  void loop();
+    void set_cmds(struct cmd_def** defs);
+    void set_handle(void* hande);
+    void set_handle2(void* hande);
+    void set_prompt(const char* prompt);
+    void* get_handle();
+    void* get_handle2();
+    void loop();
 
- protected:
-  struct cmd_def **defs;
-  void *handle;
-  void *handle2;
-  char *prompt;
-  static bool class_initialized;
+  protected:
+    struct cmd_def** defs;
+    void* handle;
+    void* handle2;
+    char* prompt;
+    static bool class_initialized;
 
-  int do_cmd(struct cmd_def **defs, int argc, char **argv);
-  int parse(struct cmd_def **defs, char *str, enum shell_error *errp);
+    int do_cmd(struct cmd_def** defs, int argc, char** argv);
+    int parse(struct cmd_def** defs, char* str, enum shell_error* errp);
 };
 
 #endif


### PR DESCRIPTION
The goal of this PR is to introduce an automated way to format the code (in order to have a consistent looking, and thus easy to read, code).

I started with the LLVM coding-style + some adapations (mainly to improve the merge-friendliness of the diffs generated when we will change the code).

If something bother you, it's open to discussion: we can still change the configuration (see [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)) before it gets merged (after the merge, it will be best to avoid further change to avoid crazy diff that decrease the value of `git blame`).

Note that if you use Vim or Emacs, `clang-format` is delivered with scripts that allows you to run clang-format seemlessly as you code (see [here](https://clang.llvm.org/docs/ClangFormat.html#vim-integration)).