### PR TITLE
Linting with clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 kadsim
 gethclient.h
+kadclient.h

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,7 @@ To ensure consistency throughout the source code, please format your code using
 
 `clang-format` can be integrated with several text editor such as Emacs and Vim,
 see the [documentation](https://clang.llvm.org/docs/ClangFormat.html)
+
+## Code quality
+
+Ensure that your code compile without warning from the compiler and the linter.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - ./lint.rb

--- a/lint.rb
+++ b/lint.rb
@@ -4,6 +4,7 @@
 COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
   cert-*
+  modernize-*
   performance-*
   readability-*
 ].freeze

--- a/lint.rb
+++ b/lint.rb
@@ -10,6 +10,15 @@ CHECKS = %w[
   google-readability-casting
   google-runtime-member-string-references
   google-runtime-int
+  hicpp-avoid-goto
+  hicpp-exception-baseclass
+  hicpp-member-init
+  hicpp-no-array-decay
+  hicpp-no-assembler
+  hicpp-no-malloc
+  hicpp-signed-bitwise
+  hicpp-special-member-functions
+  hicpp-vararg
   modernize-*
   performance-*
   readability-*

--- a/lint.rb
+++ b/lint.rb
@@ -3,7 +3,11 @@
 
 COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
+  android-*
+  boost-*
+  bugprone-*
   cert-*
+  clang-analyzer-*
   google-build-explicit-make-pair
   google-default-arguments
   google-explicit-constructor
@@ -19,7 +23,9 @@ CHECKS = %w[
   hicpp-signed-bitwise
   hicpp-special-member-functions
   hicpp-vararg
+  misc-*
   modernize-*
+  mpi-*
   performance-*
   readability-*
 ].freeze

--- a/lint.rb
+++ b/lint.rb
@@ -5,6 +5,7 @@ COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
   cert-*
   performance-*
+  readability-*
 ].freeze
 
 BLACKLIST = %w[

--- a/lint.rb
+++ b/lint.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+COMPIL_OPTS = '-x c++ --std=c++11'.freeze
+CHECKS = %w[
+].freeze
+
+BLACKLIST = %w[
+  src/gethclient.h
+  src/kadclient.h
+].freeze
+TO_CHECK = Dir.glob('src/*.{cpp,h}') - BLACKLIST
+
+exec("clang-tidy #{TO_CHECK.join(' ')} "\
+     "-checks='#{CHECKS.join(',')}' -- #{COMPIL_OPTS}")

--- a/lint.rb
+++ b/lint.rb
@@ -4,6 +4,7 @@
 COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
   cert-*
+  performance-*
 ].freeze
 
 BLACKLIST = %w[

--- a/lint.rb
+++ b/lint.rb
@@ -4,6 +4,12 @@
 COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
   cert-*
+  google-build-explicit-make-pair
+  google-default-arguments
+  google-explicit-constructor
+  google-readability-casting
+  google-runtime-member-string-references
+  google-runtime-int
   modernize-*
   performance-*
   readability-*

--- a/lint.rb
+++ b/lint.rb
@@ -3,6 +3,7 @@
 
 COMPIL_OPTS = '-x c++ --std=c++11'.freeze
 CHECKS = %w[
+  cert-*
 ].freeze
 
 BLACKLIST = %w[

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,31 @@
 CC = clang++
 
-CFLAGS = -std=c++11 -g -Wall -Werror -DHAVE_READLINE
+CFLAGS = \
+-std=c++11 -g -Werror -Wall -Wextra -Wdeprecated -Wpedantic \
+-Wdocumentation -Wdocumentation-pedantic \
+-Wconversion -Wno-sign-conversion \
+-Wunused-exception-parameter -Wunused-macros -Wunused-member-function -Wunused-template \
+-Wgcc-compat -Wgnu \
+-Warray-bounds-pointer-arithmetic \
+-Wassign-enum \
+-Wbad-function-cast \
+-Wconditional-uninitialized \
+-Wduplicate-method-arg -Wduplicate-method-match \
+-Wfloat-equal \
+-Wformat-pedantic \
+-Wlarge-by-value-copy \
+-Wmissing-noreturn -Wmissing-prototypes \
+-Wnested-anon-types \
+-Wnon-virtual-dtor \
+-Wold-style-cast \
+-Woverlength-strings \
+-Wshift-sign-overflow \
+-Wstring-compare -Wstring-conversion -Wstring-plus-char \
+-Wsometimes-uninitialized \
+-Wswitch-enum \
+-Wunreachable-code-aggressive \
+-DHAVE_READLINE
+
 LDFLAGS = \
 -lcrypto \
 -lreadline \

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -11,8 +11,8 @@
 
 #include <openssl/bn.h>
 
-using int64 = long long;
-using uint64 = unsigned long long;
+using int64 = long long;           // NOLINT(google-runtime-int)
+using uint64 = unsigned long long; // NOLINT(google-runtime-int)
 
 /** Errors thrown by the bignum class. */
 class bignum_error : public std::runtime_error {
@@ -46,7 +46,7 @@ class CAutoBN_CTX {
         }
     }
 
-    operator BN_CTX*()
+    operator BN_CTX*() // NOLINT(google-explicit-constructor)
     {
         return pctx;
     }
@@ -97,6 +97,7 @@ class CBigNum {
     }
 
     // CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(signed char n) : CBigNum()
     {
         if (n >= 0) {
@@ -106,6 +107,7 @@ class CBigNum {
         }
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(short n) : CBigNum()
     {
         if (n >= 0) {
@@ -115,6 +117,7 @@ class CBigNum {
         }
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(int n) : CBigNum()
     {
         if (n >= 0) {
@@ -124,6 +127,7 @@ class CBigNum {
         }
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(long n) : CBigNum()
     {
         if (n >= 0) {
@@ -133,31 +137,37 @@ class CBigNum {
         }
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(int64 n) : CBigNum()
     {
         setint64(n);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(unsigned char n) : CBigNum()
     {
         setulong(n);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(unsigned short n) : CBigNum()
     {
         setulong(n);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(unsigned int n) : CBigNum()
     {
         setulong(n);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(unsigned long n) : CBigNum()
     {
         setulong(n);
     }
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     CBigNum(uint64 n) : CBigNum()
     {
         setuint64(n);
@@ -168,7 +178,7 @@ class CBigNum {
         setvch(vch);
     }
 
-    void setulong(unsigned long n)
+    void setulong(unsigned long n) // NOLINT(google-runtime-int)
     {
         if (BN_set_word(bn, n) == 0) {
             throw bignum_error(
@@ -176,7 +186,7 @@ class CBigNum {
         }
     }
 
-    unsigned long getulong() const
+    unsigned long getulong() const // NOLINT(google-runtime-int)
     {
         return BN_get_word(bn);
     }
@@ -193,7 +203,7 @@ class CBigNum {
         bool fNegative;
         uint64 n;
 
-        if (sn < (int64)0) {
+        if (sn < static_cast<int64>(0)) {
             // Since the minimum signed integer cannot be represented as
             // positive so long as its type is signed, and it's not well-defined
             // what happens if you make it unsigned before negating it, we
@@ -379,7 +389,7 @@ class CBigNum {
         *this = 0;
         while (isxdigit(*psz) != 0) {
             *this <<= 4;
-            int n = phexdigit[(unsigned char)*psz++];
+            int n = phexdigit[static_cast<unsigned char>(*psz++)];
             *this += n;
         }
         if (fNegative) {

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -65,6 +65,11 @@ class CAutoBN_CTX {
     {
         return (pctx == nullptr);
     }
+
+    CAutoBN_CTX(CAutoBN_CTX const&) = delete;
+    CAutoBN_CTX& operator=(CAutoBN_CTX const& x) = delete;
+    CAutoBN_CTX(CAutoBN_CTX&&) = delete;
+    CAutoBN_CTX& operator=(CAutoBN_CTX&& x) = delete;
 };
 
 /** C++ wrapper for BIGNUM (OpenSSL bignum). */
@@ -83,12 +88,23 @@ class CBigNum {
         }
     }
 
+    CBigNum(CBigNum&& b) : bn(b.bn)
+    {
+        b.bn = nullptr;
+    }
+
     CBigNum& operator=(const CBigNum& b)
     {
         if (BN_copy(bn, b.bn) == nullptr) {
             throw bignum_error("CBigNum::operator= : BN_copy failed");
         }
-        return (*this);
+        return *this;
+    }
+
+    CBigNum& operator=(CBigNum&& b)
+    {
+        std::swap(bn, b.bn);
+        return *this;
     }
 
     ~CBigNum()
@@ -400,8 +416,8 @@ class CBigNum {
     std::string ToString(int nBase = 10) const
     {
         CAutoBN_CTX pctx;
-        CBigNum bnBase = nBase;
-        CBigNum bn0 = 0;
+        CBigNum bnBase(nBase);
+        CBigNum bn0(0);
         std::string str;
         CBigNum bn = *this;
         BN_set_negative(bn.bn, 0);
@@ -455,7 +471,7 @@ class CBigNum {
 
     inline void Rand(int n_bits)
     {
-        CBigNum range = 0;
+        CBigNum range(0);
         BN_set_bit(range.bn, n_bits);
         BN_rand_range(bn, range.bn);
     }
@@ -514,7 +530,7 @@ class CBigNum {
         // number
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of
         //   OpenSSL
-        CBigNum a = 1;
+        CBigNum a(1);
         a <<= shift;
         if (BN_cmp(a.bn, bn) > 0) {
             *this = 0;

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -208,11 +208,6 @@ class CBigNum {
         return BN_get_word(bn);
     }
 
-    unsigned int getuint() const
-    {
-        return BN_get_word(bn);
-    }
-
     void setint64(int64 sn)
     {
         unsigned char pch[sizeof(sn) + 6];
@@ -251,12 +246,12 @@ class CBigNum {
             }
             *p++ = c;
         }
-        unsigned int nSize = p - (pch + 4);
+        uint64 nSize = p - (pch + 4);
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize)&0xff;
-        BN_mpi2bn(pch, p - pch, bn);
+        BN_mpi2bn(pch, static_cast<int>(p - pch), bn);
     }
 
     void setuint64(uint64 n)
@@ -278,18 +273,18 @@ class CBigNum {
             }
             *p++ = c;
         }
-        unsigned int nSize = p - (pch + 4);
+        uint64 nSize = p - (pch + 4);
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize)&0xff;
-        BN_mpi2bn(pch, p - pch, bn);
+        BN_mpi2bn(pch, static_cast<int>(p - pch), bn);
     }
 
     void setvch(const std::vector<unsigned char>& vch)
     {
         std::vector<unsigned char> vch2(vch.size() + 4);
-        unsigned int nSize = vch.size();
+        uint64 nSize = vch.size();
         // BIGNUM's byte stream format expects 4 bytes of
         // big endian size data info at the front
         vch2[0] = (nSize >> 24) & 0xff;
@@ -298,7 +293,7 @@ class CBigNum {
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
         reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
-        BN_mpi2bn(&vch2[0], vch2.size(), bn);
+        BN_mpi2bn(&vch2[0], static_cast<int>(vch2.size()), bn);
     }
 
     std::vector<unsigned char> getvch() const
@@ -352,15 +347,15 @@ class CBigNum {
         return *this;
     }
 
-    unsigned int GetCompact() const
+    uint64 GetCompact() const
     {
-        unsigned int nSize = BN_num_bytes(bn);
-        unsigned int nCompact = 0;
+        uint64 nSize = BN_num_bytes(bn);
+        uint64 nCompact = 0;
         if (nSize <= 3) {
             nCompact = BN_get_word(bn) << 8 * (3 - nSize);
         } else {
             CBigNum b;
-            BN_rshift(b.bn, bn, 8 * (nSize - 3));
+            BN_rshift(b.bn, bn, 8 * (static_cast<int>(nSize) - 3));
             nCompact = BN_get_word(b.bn);
         }
         // The 0x00800000 bit denotes the sign.
@@ -432,7 +427,7 @@ class CBigNum {
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             }
             bn = dv;
-            unsigned int c = rem.getulong();
+            uint64 c = rem.getulong();
             str += "0123456789abcdef"[c];
         }
         if (BN_is_negative(this->bn) != 0) {

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -11,8 +11,8 @@
 
 #include <openssl/bn.h>
 
-typedef long long int64;
-typedef unsigned long long uint64;
+using int64 = long long;
+using uint64 = unsigned long long;
 
 /** Errors thrown by the bignum class. */
 class bignum_error : public std::runtime_error {
@@ -34,14 +34,14 @@ class CAutoBN_CTX {
     CAutoBN_CTX()
     {
         pctx = BN_CTX_new();
-        if (pctx == NULL) {
+        if (pctx == nullptr) {
             throw bignum_error("CAutoBN_CTX : BN_CTX_new() returned NULL");
         }
     }
 
     ~CAutoBN_CTX()
     {
-        if (pctx != NULL) {
+        if (pctx != nullptr) {
             BN_CTX_free(pctx);
         }
     }
@@ -63,7 +63,7 @@ class CAutoBN_CTX {
 
     bool operator!()
     {
-        return (pctx == NULL);
+        return (pctx == nullptr);
     }
 };
 
@@ -276,7 +276,7 @@ class CBigNum {
 
     std::vector<unsigned char> getvch() const
     {
-        unsigned int nSize = BN_bn2mpi(bn, NULL);
+        unsigned int nSize = BN_bn2mpi(bn, nullptr);
         if (nSize <= 4) {
             return std::vector<unsigned char>();
         }
@@ -611,7 +611,7 @@ inline const CBigNum operator/(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (BN_div(r.bn, NULL, a.bn, b.bn, pctx) == 0) {
+    if (BN_div(r.bn, nullptr, a.bn, b.bn, pctx) == 0) {
         throw bignum_error("CBigNum::operator/ : BN_div failed");
     }
     return r;

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -25,6 +25,7 @@ class CAutoBN_CTX {
   protected:
     BN_CTX* pctx;
 
+    // NOLINTNEXTLINE(misc-unconventional-assign-operator)
     BN_CTX* operator=(BN_CTX* pnew)
     {
         return pctx = pnew;
@@ -88,7 +89,7 @@ class CBigNum {
         }
     }
 
-    CBigNum(CBigNum&& b) : bn(b.bn)
+    CBigNum(CBigNum&& b) noexcept : bn(b.bn)
     {
         b.bn = nullptr;
     }
@@ -101,7 +102,7 @@ class CBigNum {
         return *this;
     }
 
-    CBigNum& operator=(CBigNum&& b)
+    CBigNum& operator=(CBigNum&& b) noexcept
     {
         std::swap(bn, b.bn);
         return *this;

--- a/src/bit_map.cpp
+++ b/src/bit_map.cpp
@@ -5,9 +5,11 @@
 /** Check that all bits are taken. */
 bool BitMap::check()
 {
-    for (int i = 0; i < n_bits; i++)
-        if (get_bit(i))
+    for (int i = 0; i < n_bits; i++) {
+        if (get_bit(i) != 0) {
             return false;
+        }
+    }
 
     return true;
 }
@@ -43,7 +45,7 @@ void BitMap::clear_bit(int i)
 
 int BitMap::get_bit(int i)
 {
-    return b[i / 8] & (1 << (i & 7)) ? 1 : 0;
+    return (b[i / 8] & (1 << (i & 7))) != 0 ? 1 : 0;
 }
 
 int BitMap::get_rand_bit()
@@ -61,8 +63,7 @@ int BitMap::get_rand_bit()
         set_bit(bit);
         pos++;
         return bit;
-    } else {
-        std::cout << "error pos=" << pos << " nbits=" << n_bits << std::endl;
-        exit(EXIT_FAILURE);
     }
+    std::cout << "error pos=" << pos << " nbits=" << n_bits << std::endl;
+    exit(EXIT_FAILURE);
 }

--- a/src/bit_map.cpp
+++ b/src/bit_map.cpp
@@ -1,17 +1,6 @@
+#include <algorithm>
+
 #include "kadsim.h"
-
-void BitMap::shuffle()
-{
-    for (int i = 0; i < n_bits; i++)
-        reservoir[i] = i;
-
-    for (int i = n_bits - 1; i > 0; --i) {
-        int j = rand() % i;
-        int tmp = reservoir[j];
-        reservoir[j] = reservoir[i];
-        reservoir[i] = tmp;
-    }
-}
 
 /** Check that all bits are taken. */
 bool BitMap::check()
@@ -29,8 +18,11 @@ BitMap::BitMap(int n_bits)
 
     b = new char[(n_bits + 7) / 8]();
 
-    reservoir = new int[n_bits];
-    shuffle();
+    reservoir.reserve(n_bits);
+    for (int n = 0; n < n_bits; ++n) {
+        reservoir.push_back(n);
+    }
+    shuffle(reservoir.begin(), reservoir.end(), prng());
     pos = 0;
 }
 

--- a/src/bit_map.h
+++ b/src/bit_map.h
@@ -10,14 +10,17 @@ class BitMap {
     explicit BitMap(int n_bits);
     ~BitMap();
 
+    BitMap(BitMap const&) = delete;
+    BitMap& operator=(BitMap const& x) = delete;
+    BitMap(BitMap&&) = delete;
+    BitMap& operator=(BitMap&& x) = delete;
+
     int get_bit(int i);
     int
     get_rand_bit(); /* Get a random bit that has never been generated before. */
     bool check();
 
   private:
-    // DISALLOW_COPY_AND_ASSIGN(BitMap);
-
     int n_bits;
     char* b;
     std::vector<int> reservoir;

--- a/src/bit_map.h
+++ b/src/bit_map.h
@@ -7,7 +7,7 @@
 
 class BitMap {
   public:
-    BitMap(int n_bits);
+    explicit BitMap(int n_bits);
     ~BitMap();
 
     int get_bit(int i);

--- a/src/bit_map.h
+++ b/src/bit_map.h
@@ -1,6 +1,8 @@
 #ifndef __BITMAP_H__
 #define __BITMAP_H__ 1
 
+#include <vector>
+
 #include "kadsim.h"
 
 class BitMap {
@@ -18,13 +20,11 @@ class BitMap {
 
     int n_bits;
     char* b;
-    int* reservoir;
+    std::vector<int> reservoir;
     int pos;
 
     void set_bit(int i);
     void clear_bit(int i);
-
-    void shuffle();
 };
 
 #endif

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -1,11 +1,11 @@
 #include "kadsim.h"
 
-int cmd_quit(Shell* shell, int argc, char** argv)
+int cmd_quit(Shell* /*shell*/, int /*argc*/, char** /*argv*/)
 {
     return SHELL_RETURN;
 }
 
-int cmd_help(Shell* shell, int argc, char** argv)
+int cmd_help(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc == 1) {
         struct cmd_def* cmdp;
@@ -38,17 +38,17 @@ int cmd_help(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-void cb_display_node(KadNode* node, void* cb_arg)
+void cb_display_node(KadNode* node, void* /*cb_arg*/)
 {
     std::cout << node->get_id().ToString(16) << "\n";
 }
 
-void cb_display_routable(const KadRoutable& routable, void* cb_arg)
+void cb_display_routable(const KadRoutable& routable, void* /*cb_arg*/)
 {
     std::cout << routable.get_id().ToString(16) << "\n";
 }
 
-int cmd_rand_node(Shell* shell, int argc, char** argv)
+int cmd_rand_node(Shell* shell, int /*argc*/, char** /*argv*/)
 {
     auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
@@ -57,7 +57,7 @@ int cmd_rand_node(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_rand_key(Shell* shell, int argc, char** argv)
+int cmd_rand_key(Shell* shell, int /*argc*/, char** /*argv*/)
 {
     auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
@@ -145,7 +145,7 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_show(Shell* shell, int argc, char** argv)
+int cmd_show(Shell* shell, int argc, char** /*argv*/)
 {
     if (argc != 1) {
         fprintf(stderr, "usage: show\n");
@@ -222,7 +222,7 @@ int cmd_save(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_xor(Shell* shell, int argc, char** argv)
+int cmd_xor(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: xor bn1 bn2\n");
@@ -242,7 +242,7 @@ int cmd_xor(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_bit_length(Shell* shell, int argc, char** argv)
+int cmd_bit_length(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: bit_length bn\n");

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -50,7 +50,7 @@ void cb_display_routable(const KadRoutable& routable, void* cb_arg)
 
 int cmd_rand_node(Shell* shell, int argc, char** argv)
 {
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     network->rand_node(cb_display_node, nullptr);
 
@@ -59,7 +59,7 @@ int cmd_rand_node(Shell* shell, int argc, char** argv)
 
 int cmd_rand_key(Shell* shell, int argc, char** argv)
 {
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     network->rand_routable(cb_display_routable, nullptr);
 
@@ -73,7 +73,7 @@ int cmd_jump(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     KadNode* node = network->lookup_cheat(argv[1]);
     if (nullptr == node) {
@@ -93,7 +93,7 @@ int cmd_lookup(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
 
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
@@ -122,7 +122,7 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
 
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
@@ -152,7 +152,7 @@ int cmd_show(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
 
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
@@ -171,7 +171,7 @@ int cmd_verbose(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
 
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
@@ -190,7 +190,7 @@ int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     CBigNum bn;
     bn.SetHex(argv[1]);
@@ -214,7 +214,7 @@ int cmd_save(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     std::ofstream fout(argv[1]);
     network->save(fout);
@@ -264,7 +264,7 @@ int cmd_graphviz(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* network = (KadNetwork*)shell->get_handle();
+    auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
     std::ofstream fout(argv[1]);
     network->graphviz(fout);
@@ -279,7 +279,7 @@ int cmd_buy_storage(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
@@ -297,7 +297,7 @@ int cmd_put_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
@@ -315,7 +315,7 @@ int cmd_get_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    auto* node = (KadNode*)shell->get_handle2();
+    auto* node = static_cast<KadNode*>(shell->get_handle2());
     if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -50,18 +50,18 @@ void cb_display_routable(const KadRoutable& routable, void* cb_arg)
 
 int cmd_rand_node(Shell* shell, int argc, char** argv)
 {
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
-    network->rand_node(cb_display_node, NULL);
+    network->rand_node(cb_display_node, nullptr);
 
     return SHELL_CONT;
 }
 
 int cmd_rand_key(Shell* shell, int argc, char** argv)
 {
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
-    network->rand_routable(cb_display_routable, NULL);
+    network->rand_routable(cb_display_routable, nullptr);
 
     return SHELL_CONT;
 }
@@ -73,10 +73,10 @@ int cmd_jump(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
     KadNode* node = network->lookup_cheat(argv[1]);
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "not found\n");
         return SHELL_CONT;
     }
@@ -93,9 +93,9 @@ int cmd_lookup(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
+    auto* node = (KadNode*)shell->get_handle2();
 
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -122,9 +122,9 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
+    auto* node = (KadNode*)shell->get_handle2();
 
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -152,9 +152,9 @@ int cmd_show(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
+    auto* node = (KadNode*)shell->get_handle2();
 
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -171,9 +171,9 @@ int cmd_verbose(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
+    auto* node = (KadNode*)shell->get_handle2();
 
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -190,19 +190,19 @@ int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
     CBigNum bn;
     bn.SetHex(argv[1]);
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
     KadNode* node = network->find_nearest_cheat(routable);
-    if (NULL == node) {
+    if (nullptr == node) {
         fprintf(stderr, "not found\n");
         return SHELL_CONT;
     }
 
-    cb_display_node(node, NULL);
+    cb_display_node(node, nullptr);
 
     return SHELL_CONT;
 }
@@ -214,7 +214,7 @@ int cmd_save(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
     std::ofstream fout(argv[1]);
     network->save(fout);
@@ -264,7 +264,7 @@ int cmd_graphviz(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNetwork* network = (KadNetwork*)shell->get_handle();
+    auto* network = (KadNetwork*)shell->get_handle();
 
     std::ofstream fout(argv[1]);
     network->graphviz(fout);
@@ -279,8 +279,8 @@ int cmd_buy_storage(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
-    if (NULL == node) {
+    auto* node = (KadNode*)shell->get_handle2();
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -297,8 +297,8 @@ int cmd_put_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
-    if (NULL == node) {
+    auto* node = (KadNode*)shell->get_handle2();
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -315,8 +315,8 @@ int cmd_get_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    KadNode* node = (KadNode*)shell->get_handle2();
-    if (NULL == node) {
+    auto* node = (KadNode*)shell->get_handle2();
+    if (nullptr == node) {
         fprintf(stderr, "shall jump to a node first\n");
         return SHELL_CONT;
     }
@@ -379,5 +379,5 @@ struct cmd_def* cmd_defs[] = {
     &show_cmd,
     &verbose_cmd,
     &xor_cmd,
-    NULL,
+    nullptr,
 };

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -133,7 +133,7 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
 
     std::list<KadNode*> result =
-        node->find_nearest_nodes(routable, atoi(argv[2]));
+        node->find_nearest_nodes(routable, std::stoi(argv[2]));
 
     std::list<KadNode*>::iterator it;
     for (it = result.begin(); it != result.end(); ++it)
@@ -176,7 +176,7 @@ int cmd_verbose(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    node->set_verbose(atoi(argv[1]));
+    node->set_verbose(std::stoi(argv[1]));
 
     return SHELL_CONT;
 }
@@ -283,8 +283,7 @@ int cmd_buy_storage(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    // FIXME: atoi is so dirty…
-    node->buy_storage(argv[1], atoi(argv[2]));
+    node->buy_storage(argv[1], std::stoi(argv[2]));
 
     return SHELL_CONT;
 }
@@ -302,8 +301,7 @@ int cmd_put_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    // FIXME: atoi is so dirty…
-    node->put_bytes(argv[1], atoi(argv[2]));
+    node->put_bytes(argv[1], std::stoi(argv[2]));
 
     return SHELL_CONT;
 }
@@ -321,8 +319,7 @@ int cmd_get_bytes(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    // FIXME: atoi is so dirty…
-    node->get_bytes(argv[1], atoi(argv[2]));
+    node->get_bytes(argv[1], std::stoi(argv[2]));
 
     return SHELL_CONT;
 }

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -12,7 +12,7 @@ int cmd_help(Shell* shell, int argc, char** argv)
         int i, j;
 
         j = 0;
-        for (i = 0; cmd_defs[i]; i++) {
+        for (i = 0; cmd_defs[i] != nullptr; i++) {
             cmdp = cmd_defs[i];
             printf("%16s", cmdp->name);
             j++;
@@ -26,9 +26,9 @@ int cmd_help(Shell* shell, int argc, char** argv)
         struct cmd_def* cmdp;
         int i;
 
-        for (i = 0; cmd_defs[i]; i++) {
+        for (i = 0; cmd_defs[i] != nullptr; i++) {
             cmdp = cmd_defs[i];
-            if (!strcmp(argv[1], cmdp->name)) {
+            if (strcmp(argv[1], cmdp->name) == 0) {
                 printf("%s\n", cmdp->purpose);
                 break;
             }
@@ -107,9 +107,10 @@ int cmd_lookup(Shell* shell, int argc, char** argv)
     std::list<KadNode*> result = node->lookup(routable);
 
     std::list<KadNode*>::iterator it;
-    for (it = result.begin(); it != result.end(); ++it)
+    for (it = result.begin(); it != result.end(); ++it) {
         std::cout << "id " << (*it)->get_id().ToString(16) << " dist "
                   << (*it)->distance_to(routable).ToString(16) << "\n";
+    }
 
     return SHELL_CONT;
 }
@@ -136,9 +137,10 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
         node->find_nearest_nodes(routable, std::stoi(argv[2]));
 
     std::list<KadNode*>::iterator it;
-    for (it = result.begin(); it != result.end(); ++it)
+    for (it = result.begin(); it != result.end(); ++it) {
         std::cout << "id " << (*it)->get_id().ToString(16) << " dist "
                   << (*it)->distance_to(routable).ToString(16) << "\n";
+    }
 
     return SHELL_CONT;
 }
@@ -176,7 +178,7 @@ int cmd_verbose(Shell* shell, int argc, char** argv)
         return SHELL_CONT;
     }
 
-    node->set_verbose(std::stoi(argv[1]));
+    node->set_verbose(std::stoi(argv[1]) != 0);
 
     return SHELL_CONT;
 }

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -43,7 +43,7 @@ void cb_display_node(KadNode* node, void* cb_arg)
     std::cout << node->get_id().ToString(16) << "\n";
 }
 
-void cb_display_routable(KadRoutable routable, void* cb_arg)
+void cb_display_routable(const KadRoutable& routable, void* cb_arg)
 {
     std::cout << routable.get_id().ToString(16) << "\n";
 }

--- a/src/cmds.cpp
+++ b/src/cmds.cpp
@@ -1,11 +1,11 @@
 #include "kadsim.h"
 
-int cmd_quit(Shell* /*shell*/, int /*argc*/, char** /*argv*/)
+static int cmd_quit(Shell* /*shell*/, int /*argc*/, char** /*argv*/)
 {
     return SHELL_RETURN;
 }
 
-int cmd_help(Shell* /*shell*/, int argc, char** argv)
+static int cmd_help(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc == 1) {
         struct cmd_def* cmdp;
@@ -38,17 +38,17 @@ int cmd_help(Shell* /*shell*/, int argc, char** argv)
     return SHELL_CONT;
 }
 
-void cb_display_node(KadNode* node, void* /*cb_arg*/)
+static void cb_display_node(KadNode* node, void* /*cb_arg*/)
 {
     std::cout << node->get_id().ToString(16) << "\n";
 }
 
-void cb_display_routable(const KadRoutable& routable, void* /*cb_arg*/)
+static void cb_display_routable(const KadRoutable& routable, void* /*cb_arg*/)
 {
     std::cout << routable.get_id().ToString(16) << "\n";
 }
 
-int cmd_rand_node(Shell* shell, int /*argc*/, char** /*argv*/)
+static int cmd_rand_node(Shell* shell, int /*argc*/, char** /*argv*/)
 {
     auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
@@ -57,7 +57,7 @@ int cmd_rand_node(Shell* shell, int /*argc*/, char** /*argv*/)
     return SHELL_CONT;
 }
 
-int cmd_rand_key(Shell* shell, int /*argc*/, char** /*argv*/)
+static int cmd_rand_key(Shell* shell, int /*argc*/, char** /*argv*/)
 {
     auto* network = static_cast<KadNetwork*>(shell->get_handle());
 
@@ -66,7 +66,7 @@ int cmd_rand_key(Shell* shell, int /*argc*/, char** /*argv*/)
     return SHELL_CONT;
 }
 
-int cmd_jump(Shell* shell, int argc, char** argv)
+static int cmd_jump(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: jump key\n");
@@ -86,7 +86,7 @@ int cmd_jump(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_lookup(Shell* shell, int argc, char** argv)
+static int cmd_lookup(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: lookup key\n");
@@ -115,7 +115,7 @@ int cmd_lookup(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_find_nearest(Shell* shell, int argc, char** argv)
+static int cmd_find_nearest(Shell* shell, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: find_nearest key amount\n");
@@ -145,7 +145,7 @@ int cmd_find_nearest(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_show(Shell* shell, int argc, char** /*argv*/)
+static int cmd_show(Shell* shell, int argc, char** /*argv*/)
 {
     if (argc != 1) {
         fprintf(stderr, "usage: show\n");
@@ -164,7 +164,7 @@ int cmd_show(Shell* shell, int argc, char** /*argv*/)
     return SHELL_CONT;
 }
 
-int cmd_verbose(Shell* shell, int argc, char** argv)
+static int cmd_verbose(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: verbose 1|0\n");
@@ -183,7 +183,7 @@ int cmd_verbose(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
+static int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: jump key\n");
@@ -207,7 +207,7 @@ int cmd_cheat_lookup(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_save(Shell* shell, int argc, char** argv)
+static int cmd_save(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: save file\n");
@@ -222,7 +222,7 @@ int cmd_save(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_xor(Shell* /*shell*/, int argc, char** argv)
+static int cmd_xor(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: xor bn1 bn2\n");
@@ -242,7 +242,7 @@ int cmd_xor(Shell* /*shell*/, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_bit_length(Shell* /*shell*/, int argc, char** argv)
+static int cmd_bit_length(Shell* /*shell*/, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: bit_length bn\n");
@@ -257,7 +257,7 @@ int cmd_bit_length(Shell* /*shell*/, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_graphviz(Shell* shell, int argc, char** argv)
+static int cmd_graphviz(Shell* shell, int argc, char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: graphviz file\n");
@@ -272,7 +272,7 @@ int cmd_graphviz(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_buy_storage(Shell* shell, int argc, char** argv)
+static int cmd_buy_storage(Shell* shell, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: buy_storage SELLER N_BYTES\n");
@@ -290,7 +290,7 @@ int cmd_buy_storage(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_put_bytes(Shell* shell, int argc, char** argv)
+static int cmd_put_bytes(Shell* shell, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: put_bytes SELLER N_BYTES\n");
@@ -308,7 +308,7 @@ int cmd_put_bytes(Shell* shell, int argc, char** argv)
     return SHELL_CONT;
 }
 
-int cmd_get_bytes(Shell* shell, int argc, char** argv)
+static int cmd_get_bytes(Shell* shell, int argc, char** argv)
 {
     if (argc != 3) {
         fprintf(stderr, "usage: get_bytes SELLER N_BYTES\n");

--- a/src/kad_file.cpp
+++ b/src/kad_file.cpp
@@ -6,8 +6,6 @@ KadFile::KadFile(const CBigNum& id, KadNode* referencer)
     this->referencer = referencer;
 }
 
-KadFile::~KadFile() {}
-
 KadNode* KadFile::get_referencer()
 {
     return referencer;

--- a/src/kad_file.cpp
+++ b/src/kad_file.cpp
@@ -1,6 +1,6 @@
 #include "kadsim.h"
 
-KadFile::KadFile(CBigNum id, KadNode* referencer)
+KadFile::KadFile(const CBigNum& id, KadNode* referencer)
     : KadRoutable(id, KAD_ROUTABLE_FILE)
 {
     this->referencer = referencer;

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -52,6 +52,7 @@ void KadNetwork::initialize_nodes(
 
     // Continue creating conns for the nodes that dont meet the initial number
     // required.
+    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
     for (u_int i = 0; i < conf->n_nodes; i++) {
         KadNode* node = nodes[i];
 
@@ -71,8 +72,7 @@ void KadNetwork::initialize_nodes(
             }
 
             // Pick a random node.
-            int x = rand() % nodes.size();
-            other = nodes[x];
+            other = nodes[dis(prng())];
 
             // Connect them 2-way.
             node->add_conn(other, false);
@@ -87,6 +87,8 @@ void KadNetwork::initialize_nodes(
 
 void KadNetwork::initialize_files(int n_files)
 {
+    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+
     std::cout << "initialize files\n";
 
     for (int i = 0; i < n_files; i++) {
@@ -95,8 +97,7 @@ void KadNetwork::initialize_files(int n_files)
                       << "                   \r";
 
         // Take a random node.
-        int x = rand() % nodes.size();
-        KadNode* node = nodes[x];
+        KadNode* node = nodes[dis(prng())];
 
         // Gen a random identifier for the file.
         CBigNum bn;
@@ -116,6 +117,8 @@ void KadNetwork::initialize_files(int n_files)
 /** Check that files are accessible from random nodes. */
 void KadNetwork::check_files()
 {
+    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+
     std::cout << "checking files\n";
 
     int n_wrong = 0;
@@ -127,8 +130,7 @@ void KadNetwork::check_files()
         KadFile* file = files[i];
 
         // Take a random node.
-        int x = rand() % nodes.size();
-        KadNode* node = nodes[x];
+        KadNode* node = nodes[dis(prng())];
 
         // Get results.
         std::list<KadNode*> result = node->lookup(*file);
@@ -161,7 +163,8 @@ void KadNetwork::check_files()
 
 void KadNetwork::rand_node(tnode_callback_func cb_func, void* cb_arg)
 {
-    int x = rand() % nodes.size();
+    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+    int x = dis(prng());
     if (NULL != cb_func)
         cb_func(nodes[x], cb_arg);
 }

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -14,10 +14,10 @@ KadNetwork::~KadNetwork() {}
 /**
  * initialize nodes
  *
- * @param n_init_conn
+ * @param n_initial_conn
  */
 void KadNetwork::initialize_nodes(
-    int n_init_conn,
+    int n_initial_conn,
     std::vector<std::string> bstraplist)
 {
     std::cout << "initialize nodes\n";
@@ -56,12 +56,13 @@ void KadNetwork::initialize_nodes(
     for (u_int i = 0; i < conf->n_nodes; i++) {
         KadNode* node = nodes[i];
 
-        if ((i % 1000) == 0)
+        if ((i % 1000) == 0) {
             std::cerr << "node " << i << "/" << conf->n_nodes
                       << "                   \r";
+        }
 
         u_int guard = 0;
-        while (node->get_n_conns() < n_init_conn) {
+        while (node->get_n_conns() < n_initial_conn) {
             KadNode* other;
 
             if (guard >= (2 * conf->n_nodes)) {
@@ -92,9 +93,10 @@ void KadNetwork::initialize_files(int n_files)
     std::cout << "initialize files\n";
 
     for (int i = 0; i < n_files; i++) {
-        if ((i % 1000) == 0)
+        if ((i % 1000) == 0) {
             std::cerr << "file " << i << "/" << n_files
                       << "                   \r";
+        }
 
         // Take a random node.
         KadNode* node = nodes[dis(prng())];
@@ -109,8 +111,9 @@ void KadNetwork::initialize_files(int n_files)
         std::list<KadNode*> result = node->lookup(*file);
         for (std::list<KadNode*>::iterator it = result.begin();
              it != result.end();
-             ++it)
+             ++it) {
             (*it)->store(file);
+        }
     }
 }
 
@@ -123,9 +126,10 @@ void KadNetwork::check_files()
 
     int n_wrong = 0;
     for (u_int i = 0; i < files.size(); i++) {
-        if ((i % 1000) == 0)
+        if ((i % 1000) == 0) {
             std::cerr << "file " << i << "/" << files.size()
                       << "                   \r";
+        }
 
         KadFile* file = files[i];
 
@@ -165,8 +169,9 @@ void KadNetwork::rand_node(tnode_callback_func cb_func, void* cb_arg)
 {
     std::uniform_int_distribution<> dis(0, nodes.size() - 1);
     int x = dis(prng());
-    if (NULL != cb_func)
+    if (NULL != cb_func) {
         cb_func(nodes[x], cb_arg);
+    }
 }
 
 void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
@@ -174,8 +179,9 @@ void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
     CBigNum bn;
     bn.Rand(conf->n_bits);
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
-    if (NULL != cb_func)
+    if (NULL != cb_func) {
         cb_func(routable, cb_arg);
+    }
 }
 
 /** Lookup a node by its id
@@ -200,14 +206,15 @@ KadNode* KadNetwork::find_nearest_cheat(const KadRoutable& routable)
     KadNode* nearest = NULL;
 
     for (u_int i = 0; i < nodes.size(); i++) {
-        if (NULL == nearest)
+        if (NULL == nearest) {
             nearest = nodes[i];
-        else {
+        } else {
             CBigNum d1 = nodes[i]->distance_to(routable);
             CBigNum d2 = nearest->distance_to(routable);
 
-            if (d1 < d2)
+            if (d1 < d2) {
                 nearest = nodes[i];
+            }
         }
     }
 

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -9,8 +9,6 @@ KadNetwork::KadNetwork(KadConf* conf)
     this->conf = conf;
 }
 
-KadNetwork::~KadNetwork() {}
-
 /**
  * initialize nodes
  *
@@ -104,15 +102,13 @@ void KadNetwork::initialize_files(int n_files)
         // Gen a random identifier for the file.
         CBigNum bn;
         bn.Rand(conf->n_bits);
-        KadFile* file = new KadFile(bn, node);
+        auto* file = new KadFile(bn, node);
         files.push_back(file);
 
         // Store file at multiple location.
         std::list<KadNode*> result = node->lookup(*file);
-        for (std::list<KadNode*>::iterator it = result.begin();
-             it != result.end();
-             ++it) {
-            (*it)->store(file);
+        for (auto& it : result) {
+            it->store(file);
         }
     }
 }
@@ -141,12 +137,9 @@ void KadNetwork::check_files()
 
         // Check that at least one result has the file.
         bool found = false;
-        for (std::list<KadNode*>::iterator it = result.begin();
-             it != result.end();
-             ++it) {
-            std::vector<KadFile*> node_files = (*it)->get_files();
-            for (u_int j = 0; j < node_files.size(); j++) {
-                KadFile* node_file = node_files[j];
+        for (auto& it : result) {
+            std::vector<KadFile*> node_files = it->get_files();
+            for (auto node_file : node_files) {
                 if (node_file == file) {
                     found = true;
                     break;
@@ -169,7 +162,7 @@ void KadNetwork::rand_node(tnode_callback_func cb_func, void* cb_arg)
 {
     std::uniform_int_distribution<> dis(0, nodes.size() - 1);
     int x = dis(prng());
-    if (NULL != cb_func) {
+    if (nullptr != cb_func) {
         cb_func(nodes[x], cb_arg);
     }
 }
@@ -179,7 +172,7 @@ void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
     CBigNum bn;
     bn.Rand(conf->n_bits);
     KadRoutable routable(bn, KAD_ROUTABLE_FILE);
-    if (NULL != cb_func) {
+    if (nullptr != cb_func) {
         cb_func(routable, cb_arg);
     }
 }
@@ -203,17 +196,17 @@ KadNode* KadNetwork::lookup_cheat(const std::string& id)
  */
 KadNode* KadNetwork::find_nearest_cheat(const KadRoutable& routable)
 {
-    KadNode* nearest = NULL;
+    KadNode* nearest = nullptr;
 
-    for (u_int i = 0; i < nodes.size(); i++) {
-        if (NULL == nearest) {
-            nearest = nodes[i];
+    for (auto& node : nodes) {
+        if (nullptr == nearest) {
+            nearest = node;
         } else {
-            CBigNum d1 = nodes[i]->distance_to(routable);
+            CBigNum d1 = node->distance_to(routable);
             CBigNum d2 = nearest->distance_to(routable);
 
             if (d1 < d2) {
-                nearest = nodes[i];
+                nearest = node;
             }
         }
     }

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -184,7 +184,7 @@ void KadNetwork::rand_routable(troutable_callback_func cb_func, void* cb_arg)
  *
  * @return the node identified by `id`
  */
-KadNode* KadNetwork::lookup_cheat(std::string id)
+KadNode* KadNetwork::lookup_cheat(const std::string& id)
 {
     return nodes_map[id];
 }
@@ -195,7 +195,7 @@ KadNode* KadNetwork::lookup_cheat(std::string id)
  *
  * @return
  */
-KadNode* KadNetwork::find_nearest_cheat(KadRoutable routable)
+KadNode* KadNetwork::find_nearest_cheat(const KadRoutable& routable)
 {
     KadNode* nearest = NULL;
 

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -20,7 +20,7 @@ void KadNetwork::initialize_nodes(
 {
     std::cout << "initialize nodes\n";
 
-    BitMap bitmap = BitMap(conf->n_nodes);
+    BitMap bitmap(conf->n_nodes);
 
     // Split the total keyspace equally among nodes.
     CBigNum keyspace = CBigNum(1);

--- a/src/kad_network.cpp
+++ b/src/kad_network.cpp
@@ -9,11 +9,7 @@ KadNetwork::KadNetwork(KadConf* conf)
     this->conf = conf;
 }
 
-/**
- * initialize nodes
- *
- * @param n_initial_conn
- */
+/** Initialize nodes. */
 void KadNetwork::initialize_nodes(
     int n_initial_conn,
     std::vector<std::string> bstraplist)
@@ -50,7 +46,7 @@ void KadNetwork::initialize_nodes(
 
     // Continue creating conns for the nodes that dont meet the initial number
     // required.
-    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+    std::uniform_int_distribution<uint64_t> dis(0, nodes.size() - 1);
     for (u_int i = 0; i < conf->n_nodes; i++) {
         KadNode* node = nodes[i];
 
@@ -86,7 +82,7 @@ void KadNetwork::initialize_nodes(
 
 void KadNetwork::initialize_files(int n_files)
 {
-    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+    std::uniform_int_distribution<uint64_t> dis(0, nodes.size() - 1);
 
     std::cout << "initialize files\n";
 
@@ -116,7 +112,7 @@ void KadNetwork::initialize_files(int n_files)
 /** Check that files are accessible from random nodes. */
 void KadNetwork::check_files()
 {
-    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
+    std::uniform_int_distribution<uint64_t> dis(0, nodes.size() - 1);
 
     std::cout << "checking files\n";
 
@@ -160,8 +156,8 @@ void KadNetwork::check_files()
 
 void KadNetwork::rand_node(tnode_callback_func cb_func, void* cb_arg)
 {
-    std::uniform_int_distribution<> dis(0, nodes.size() - 1);
-    int x = dis(prng());
+    std::uniform_int_distribution<uint64_t> dis(0, nodes.size() - 1);
+    uint64_t x = dis(prng());
     if (nullptr != cb_func) {
         cb_func(nodes[x], cb_arg);
     }
@@ -188,12 +184,7 @@ KadNode* KadNetwork::lookup_cheat(const std::string& id)
     return nodes_map[id];
 }
 
-/** Find node nearest to specified routable.
- *
- * @param routable
- *
- * @return
- */
+/** Find node nearest to specified routable. */
 KadNode* KadNetwork::find_nearest_cheat(const KadRoutable& routable)
 {
     KadNode* nearest = nullptr;

--- a/src/kad_node.cpp
+++ b/src/kad_node.cpp
@@ -104,13 +104,7 @@ KadNode::find_nearest_nodes(const KadRoutable& routable, int amount)
     return this->find_nearest_nodes_local(routable, amount);
 }
 
-/** * Find nodes closest to the given ID.
- *
- * @param routable
- * @param amount
- *
- * @return the list
- */
+/** * Find nodes closest to the given ID. */
 std::list<KadNode*>
 KadNode::find_nearest_nodes_local(const KadRoutable& routable, int amount)
 {
@@ -190,11 +184,7 @@ KadNode::find_nearest_nodes_local(const KadRoutable& routable, int amount)
     return closest;
 }
 
-/** Print a list of nodes and their distance to target.
- *
- * @param list
- * @param routable
- */
+/** Print a list of nodes and their distance to target. */
 static void print_list(
     const std::string& comment,
     std::list<KadNode*> list,
@@ -212,12 +202,7 @@ static void print_list(
     }
 }
 
-/** * Find the node closest to the given ID.
- *
- * @param routable
- *
- * @return the node
- */
+/** * Find the node closest to the given ID. */
 std::list<KadNode*> KadNode::lookup(const KadRoutable& routable)
 {
     // Pick our alpha starting nodes.

--- a/src/kad_node.cpp
+++ b/src/kad_node.cpp
@@ -1,6 +1,6 @@
 #include "kadsim.h"
 
-KadNode::KadNode(KadConf* conf, CBigNum id, std::string addr)
+KadNode::KadNode(KadConf* conf, const CBigNum& id, const std::string& addr)
     : KadRoutable(id, KAD_ROUTABLE_NODE)
 {
     this->conf = conf;
@@ -23,7 +23,7 @@ KadNode::KadNode(KadConf* conf, CBigNum id, std::string addr)
     }
 }
 
-KadNode::KadNode(KadConf* conf, CBigNum id) : KadNode(conf, id, "") {}
+KadNode::KadNode(KadConf* conf, const CBigNum& id) : KadNode(conf, id, "") {}
 
 KadNode::~KadNode() {}
 
@@ -93,7 +93,7 @@ bool KadNode::add_conn(KadNode* node, bool contacted_us)
 }
 
 std::list<KadNode*>
-KadNode::find_nearest_nodes(KadRoutable routable, int amount)
+KadNode::find_nearest_nodes(const KadRoutable& routable, int amount)
 {
     if (!this->addr.empty()) {
         Json::Value params;
@@ -115,7 +115,7 @@ KadNode::find_nearest_nodes(KadRoutable routable, int amount)
  * @return the list
  */
 std::list<KadNode*>
-KadNode::find_nearest_nodes_local(KadRoutable routable, int amount)
+KadNode::find_nearest_nodes_local(const KadRoutable& routable, int amount)
 {
     CBigNum distance = distance_to(routable);
     int bit_length = distance.bit_length();
@@ -198,9 +198,9 @@ KadNode::find_nearest_nodes_local(KadRoutable routable, int amount)
  * @param routable
  */
 static void print_list(
-    std::string comment,
+    const std::string& comment,
     std::list<KadNode*> list,
-    KadRoutable routable,
+    const KadRoutable& routable,
     std::map<KadNode*, bool>* queried)
 {
     std::cout << "---" << comment << " size " << list.size() << "\n";
@@ -219,7 +219,7 @@ static void print_list(
  *
  * @return the node
  */
-std::list<KadNode*> KadNode::lookup(KadRoutable routable)
+std::list<KadNode*> KadNode::lookup(const KadRoutable& routable)
 {
     // Pick our alpha starting nodes.
     std::list<KadNode*> starting_nodes;

--- a/src/kad_node.cpp
+++ b/src/kad_node.cpp
@@ -18,7 +18,7 @@ KadNode::KadNode(KadConf* conf, CBigNum id, std::string addr)
     try {
         this->eth_account = conf->geth.personal_newAccount(eth_passphrase);
         conf->geth.personal_unlockAccount(eth_account, eth_passphrase, 0);
-    } catch (jsonrpc::JsonRpcException) {
+    } catch (jsonrpc::JsonRpcException&) {
         this->eth_account = "";
     }
 }
@@ -446,7 +446,7 @@ void KadNode::buy_storage(const std::string& seller, uint64_t nb_bytes)
 
     try {
         call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-    } catch (jsonrpc::JsonRpcException exn) {
+    } catch (jsonrpc::JsonRpcException& exn) {
         std::cerr << "cannot buy " << nb_bytes << "bytes from " << seller
                   << ": " << exn.what() << '\n';
     }
@@ -463,7 +463,7 @@ void KadNode::put_bytes(const std::string& seller, uint64_t nb_bytes)
 
     try {
         call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-    } catch (jsonrpc::JsonRpcException exn) {
+    } catch (jsonrpc::JsonRpcException& exn) {
         std::cerr << "cannot put " << nb_bytes << "bytes on storage of "
                   << seller << ": " << exn.what() << '\n';
     }
@@ -480,7 +480,7 @@ void KadNode::get_bytes(const std::string& seller, uint64_t nb_bytes)
 
     try {
         call_contract(conf->geth, eth_account, QUADIRON_CONTRACT_ADDR, payload);
-    } catch (jsonrpc::JsonRpcException exn) {
+    } catch (jsonrpc::JsonRpcException& exn) {
         std::cerr << "cannot get " << nb_bytes << "bytes from storage of "
                   << seller << ": " << exn.what() << '\n';
     }

--- a/src/kad_routable.cpp
+++ b/src/kad_routable.cpp
@@ -1,6 +1,6 @@
 #include "kadsim.h"
 
-KadRoutable::KadRoutable(CBigNum id, enum KadRoutableType type)
+KadRoutable::KadRoutable(const CBigNum& id, enum KadRoutableType type)
 {
     this->id = id;
     this->type = type;
@@ -13,7 +13,7 @@ CBigNum KadRoutable::get_id() const
     return id;
 }
 
-CBigNum KadRoutable::distance_to(KadRoutable other) const
+CBigNum KadRoutable::distance_to(const KadRoutable& other) const
 {
     return id ^ other.get_id();
 }

--- a/src/kad_routable.cpp
+++ b/src/kad_routable.cpp
@@ -6,8 +6,6 @@ KadRoutable::KadRoutable(const CBigNum& id, enum KadRoutableType type)
     this->type = type;
 }
 
-KadRoutable::~KadRoutable() {}
-
 CBigNum KadRoutable::get_id() const
 {
     return id;

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <random>
 #include <vector>
 
 #include <getopt.h>
@@ -167,5 +168,13 @@ void call_contract(
     const std::string& node_addr,
     const std::string& contract_addr,
     const std::string& payload);
+
+// Return a reference to the global PRNG.
+static inline std::mt19937& prng()
+{
+    static std::mt19937 PRNG;
+
+    return PRNG;
+}
 
 #endif

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -38,7 +38,7 @@ class KadConf {
         int alpha,
         int n_nodes,
         const std::string& geth_addr,
-        const std::vector<std::string> bstraplist);
+        const std::vector<std::string>& bstraplist);
     void save(std::ostream& fout);
     int n_bits;
     u_int k;
@@ -57,13 +57,13 @@ enum KadRoutableType {
 
 class KadRoutable {
   public:
-    KadRoutable(CBigNum id, enum KadRoutableType);
+    KadRoutable(const CBigNum& id, enum KadRoutableType);
     ~KadRoutable();
 
     CBigNum get_id() const;
     bool is_remote();
     KadRoutableType get_type();
-    CBigNum distance_to(KadRoutable other) const;
+    CBigNum distance_to(const KadRoutable& other) const;
     bool operator()(const KadRoutable* first, const KadRoutable* second) const;
 
   protected:
@@ -78,7 +78,7 @@ class KadNode;
 
 class KadFile : public KadRoutable {
   public:
-    KadFile(CBigNum id, KadNode* referencer);
+    KadFile(const CBigNum& id, KadNode* referencer);
     ~KadFile();
     KadNode* get_referencer();
 
@@ -90,17 +90,18 @@ class KadFile : public KadRoutable {
 
 class KadNode : public KadRoutable {
   public:
-    KadNode(KadConf* conf, CBigNum id);
-    KadNode(KadConf* conf, CBigNum id, std::string addr);
+    KadNode(KadConf* conf, const CBigNum& id);
+    KadNode(KadConf* conf, const CBigNum& id, const std::string& addr);
     ~KadNode();
 
     int get_n_conns();
     const std::string& get_eth_account() const;
     bool add_conn(KadNode* node, bool contacted_us);
-    std::list<KadNode*> find_nearest_nodes(KadRoutable routable, int amount);
     std::list<KadNode*>
-    find_nearest_nodes_local(KadRoutable routable, int amount);
-    std::list<KadNode*> lookup(KadRoutable routable);
+    find_nearest_nodes(const KadRoutable& routable, int amount);
+    std::list<KadNode*>
+    find_nearest_nodes_local(const KadRoutable& routable, int amount);
+    std::list<KadNode*> lookup(const KadRoutable& routable);
     void show();
     void set_verbose(int level);
     void save(std::ostream& fout);
@@ -127,7 +128,8 @@ class KadNode : public KadRoutable {
 };
 
 typedef void (*tnode_callback_func)(KadNode* node, void* cb_arg);
-typedef void (*troutable_callback_func)(KadRoutable routable, void* cb_arg);
+typedef void (
+    *troutable_callback_func)(const KadRoutable& routable, void* cb_arg);
 
 class KadNetwork {
   public:
@@ -139,8 +141,8 @@ class KadNetwork {
     void initialize_files(int n_files);
     void rand_node(tnode_callback_func cb_func, void* cb_arg);
     void rand_routable(troutable_callback_func cb_func, void* cb_arg);
-    KadNode* lookup_cheat(std::string id);
-    KadNode* find_nearest_cheat(KadRoutable routable);
+    KadNode* lookup_cheat(const std::string& id);
+    KadNode* find_nearest_cheat(const KadRoutable& routable);
     void save(std::ostream& fout);
     void graphviz(std::ostream& fout);
     void check_files();

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -103,7 +103,7 @@ class KadNode : public KadRoutable {
     find_nearest_nodes_local(const KadRoutable& routable, int amount);
     std::list<KadNode*> lookup(const KadRoutable& routable);
     void show();
-    void set_verbose(int level);
+    void set_verbose(bool enable);
     void save(std::ostream& fout);
     void store(KadFile* file);
     std::vector<KadFile*> get_files();
@@ -120,7 +120,7 @@ class KadNode : public KadRoutable {
 
     typedef std::map<int, std::list<KadNode*>> tbucket;
     tbucket buckets;
-    int verbose;
+    bool verbose;
 
     std::vector<KadFile*> files;
     std::string eth_passphrase;

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -129,7 +129,7 @@ using troutable_callback_func = void (*)(const KadRoutable&, void*);
 
 class KadNetwork {
   public:
-    KadNetwork(KadConf* conf);
+    explicit KadNetwork(KadConf* conf);
 
     void
     initialize_nodes(int n_initial_conn, std::vector<std::string> bstraplist);

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -38,7 +38,7 @@ class KadConf {
         int alpha,
         int n_nodes,
         const std::string& geth_addr,
-        const std::vector<std::string>& bstraplist);
+        std::vector<std::string> bstraplist);
     void save(std::ostream& fout);
     int n_bits;
     u_int k;
@@ -58,7 +58,6 @@ enum KadRoutableType {
 class KadRoutable {
   public:
     KadRoutable(const CBigNum& id, enum KadRoutableType);
-    ~KadRoutable();
 
     CBigNum get_id() const;
     bool is_remote();
@@ -79,7 +78,6 @@ class KadNode;
 class KadFile : public KadRoutable {
   public:
     KadFile(const CBigNum& id, KadNode* referencer);
-    ~KadFile();
     KadNode* get_referencer();
 
   private:
@@ -92,7 +90,6 @@ class KadNode : public KadRoutable {
   public:
     KadNode(KadConf* conf, const CBigNum& id);
     KadNode(KadConf* conf, const CBigNum& id, const std::string& addr);
-    ~KadNode();
 
     int get_n_conns();
     const std::string& get_eth_account() const;
@@ -118,7 +115,7 @@ class KadNode : public KadRoutable {
 
     KadConf* conf;
 
-    typedef std::map<int, std::list<KadNode*>> tbucket;
+    using tbucket = std::map<int, std::list<KadNode*>>;
     tbucket buckets;
     bool verbose;
 
@@ -127,14 +124,12 @@ class KadNode : public KadRoutable {
     std::string eth_account;
 };
 
-typedef void (*tnode_callback_func)(KadNode* node, void* cb_arg);
-typedef void (
-    *troutable_callback_func)(const KadRoutable& routable, void* cb_arg);
+using tnode_callback_func = void (*)(KadNode*, void*);
+using troutable_callback_func = void (*)(const KadRoutable&, void*);
 
 class KadNetwork {
   public:
     KadNetwork(KadConf* conf);
-    ~KadNetwork();
 
     void
     initialize_nodes(int n_initial_conn, std::vector<std::string> bstraplist);

--- a/src/kadsim.h
+++ b/src/kadsim.h
@@ -1,12 +1,6 @@
 #ifndef __KADSIM_H__
 #define __KADSIM_H__
 
-// Most classes do not need copy or assignment constructors and should use this
-// macro to disable them.
-#define DISALLOW_COPY_AND_ASSIGN(TypeName)                                     \
-    TypeName(const TypeName&);                                                 \
-    void operator=(const TypeName&)
-
 // Address of the QuadIron contract on the blockchain.
 #define QUADIRON_CONTRACT_ADDR "0x5e667a8D97fBDb2D3923a55b295DcB8f5985FB79"
 
@@ -69,8 +63,6 @@ class KadRoutable {
     CBigNum id;
     KadRoutableType type;
     std::string addr; // Remote peer IP address, or "" if local.
-    jsonrpc::HttpClient* httpclient;
-    KadClient* kadc;
 };
 
 class KadNode;
@@ -80,16 +72,26 @@ class KadFile : public KadRoutable {
     KadFile(const CBigNum& id, KadNode* referencer);
     KadNode* get_referencer();
 
+    ~KadFile() = default;
+    KadFile(KadFile const&) = delete;
+    KadFile& operator=(KadFile const& x) = delete;
+    KadFile(KadFile&&) = delete;
+    KadFile& operator=(KadFile&& x) = delete;
+
   private:
     KadNode* referencer;
-
-    // DISALLOW_COPY_AND_ASSIGN(KadFile);
 };
 
 class KadNode : public KadRoutable {
   public:
     KadNode(KadConf* conf, const CBigNum& id);
     KadNode(KadConf* conf, const CBigNum& id, const std::string& addr);
+
+    ~KadNode() = default;
+    KadNode(KadNode const&) = delete;
+    KadNode& operator=(KadNode const& x) = delete;
+    KadNode(KadNode&&) = delete;
+    KadNode& operator=(KadNode&& x) = delete;
 
     int get_n_conns();
     const std::string& get_eth_account() const;
@@ -111,8 +113,6 @@ class KadNode : public KadRoutable {
     void get_bytes(const std::string& seller, uint64_t nb_bytes);
 
   private:
-    // DISALLOW_COPY_AND_ASSIGN(KadNode);
-
     KadConf* conf;
 
     using tbucket = std::map<int, std::list<KadNode*>>;
@@ -122,6 +122,8 @@ class KadNode : public KadRoutable {
     std::vector<KadFile*> files;
     std::string eth_passphrase;
     std::string eth_account;
+    jsonrpc::HttpClient* httpclient;
+    KadClient* kadc;
 };
 
 using tnode_callback_func = void (*)(KadNode*, void*);
@@ -130,6 +132,12 @@ using troutable_callback_func = void (*)(const KadRoutable&, void*);
 class KadNetwork {
   public:
     explicit KadNetwork(KadConf* conf);
+
+    ~KadNetwork() = default;
+    KadNetwork(KadNetwork const&) = delete;
+    KadNetwork& operator=(KadNetwork const& x) = delete;
+    KadNetwork(KadNetwork&&) = delete;
+    KadNetwork& operator=(KadNetwork&& x) = delete;
 
     void
     initialize_nodes(int n_initial_conn, std::vector<std::string> bstraplist);
@@ -143,8 +151,6 @@ class KadNetwork {
     void check_files();
 
   private:
-    // DISALLOW_COPY_AND_ASSIGN(KadNetwork);
-
     KadConf* conf;
 
     std::vector<KadNode*> nodes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ KadConf::KadConf(
     int alpha,
     int n_nodes,
     const std::string& geth_addr,
-    const std::vector<std::string> bstraplist)
+    const std::vector<std::string>& bstraplist)
     : httpclient(geth_addr), geth(httpclient), bstraplist(bstraplist)
 {
     this->n_bits = n_bits;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
     int n_init_conn = 100;
     int n_files = 5000;
     int rand_seed = 0;
-    char* fname = NULL;
+    std::string fname;
     std::string geth_addr = "localhost:8545";
     std::vector<std::string> bstraplist;
 
@@ -143,10 +143,9 @@ int main(int argc, char** argv)
             geth_addr = optarg;
             break;
         case 'B': {
-            char* bstraplist_dup = strdup(optarg);
-            char* bstrap;
-            while (NULL != (bstrap = strtok(bstraplist_dup, ","))) {
-                bstraplist_dup = NULL;
+            std::istringstream input(optarg);
+            std::string bstrap;
+            while (std::getline(input, bstrap, ',')) {
                 bstraplist.push_back(bstrap);
             }
             break;
@@ -155,7 +154,7 @@ int main(int argc, char** argv)
             rand_seed = atoi(optarg);
             break;
         case 'f':
-            fname = strdup(optarg);
+            fname = optarg;
             break;
         case 'N':
             n_files = atoi(optarg);
@@ -166,7 +165,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (fname) {
+    if (fname.empty()) {
         std::ifstream fin(fname);
         if (!fin.is_open()) {
             std::cerr << "unable to open " << fname << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ std::string encode_address(const std::string& addr)
     return oss.str();
 }
 
-void usage()
+[[noreturn]] static void usage()
 {
     std::cerr << "usage: kadsim\n";
     std::cerr << "\t-b\tn_bits\n";
@@ -100,7 +100,7 @@ void usage()
     exit(1);
 }
 
-void parse_error()
+[[noreturn]] static void parse_error()
 {
     std::cerr << "parse error\n";
     exit(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ void call_contract(
                           << '\n';
             }
             return;
-        } catch (jsonrpc::JsonRpcException exn) {
+        } catch (jsonrpc::JsonRpcException& exn) {
             if (exn.GetCode() == -32000) {
                 continue; // Transaction is pending…
             } else {
@@ -125,19 +125,19 @@ int main(int argc, char** argv)
     while ((c = getopt(argc, argv, "b:k:a:n:c:g:B:S:f:N:")) != -1) {
         switch (c) {
         case 'b':
-            n_bits = atoi(optarg);
+            n_bits = std::stoi(optarg);
             break;
         case 'k':
-            k = atoi(optarg);
+            k = std::stoi(optarg);
             break;
         case 'a':
-            alpha = atoi(optarg);
+            alpha = std::stoi(optarg);
             break;
         case 'n':
-            n_nodes = atoi(optarg);
+            n_nodes = std::stoi(optarg);
             break;
         case 'c':
-            n_init_conn = atoi(optarg);
+            n_init_conn = std::stoi(optarg);
             break;
         case 'g':
             geth_addr = optarg;
@@ -151,13 +151,13 @@ int main(int argc, char** argv)
             break;
         }
         case 'S':
-            rand_seed = atoi(optarg);
+            rand_seed = std::stoi(optarg);
             break;
         case 'f':
             fname = optarg;
             break;
         case 'N':
-            n_files = atoi(optarg);
+            n_files = std::stoi(optarg);
             break;
         case '?':
         default:
@@ -179,13 +179,13 @@ int main(int argc, char** argv)
         parse_error();                                                         \
     p++;
         GETLINE();
-        n_bits = atoi(p);
+        n_bits = std::stoi(p);
         GETLINE();
-        k = atoi(p);
+        k = std::stoi(p);
         GETLINE();
-        alpha = atoi(p);
+        alpha = std::stoi(p);
         GETLINE();
-        n_nodes = atoi(p);
+        n_nodes = std::stoi(p);
     }
 
     KadConf conf(n_bits, k, alpha, n_nodes, geth_addr, bstraplist);
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
     KadNetwork network(&conf);
     Shell shell;
 
-    srand(rand_seed);
+    prng().seed(rand_seed);
 
     network.initialize_nodes(n_init_conn, bstraplist);
     network.initialize_files(n_files);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 #include "kadsim.h"
 
@@ -9,8 +10,8 @@ KadConf::KadConf(
     int alpha,
     int n_nodes,
     const std::string& geth_addr,
-    const std::vector<std::string>& bstraplist)
-    : httpclient(geth_addr), geth(httpclient), bstraplist(bstraplist)
+    std::vector<std::string> bstraplist)
+    : httpclient(geth_addr), geth(httpclient), bstraplist(std::move(bstraplist))
 {
     this->n_bits = n_bits;
     this->k = k;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,10 +57,9 @@ void call_contract(
         } catch (jsonrpc::JsonRpcException& exn) {
             if (exn.GetCode() == -32000) {
                 continue; // Transaction is pending…
-            } else {
-                fprintf(stderr, "error: %s\n", exn.what());
-                throw;
             }
+            fprintf(stderr, "error: %s\n", exn.what());
+            throw;
         }
     }
 }

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "shell.h"
 
 static char sargmem[SHELL_MAX_ARGV][SHELL_MAX_ARG_LEN];

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -58,7 +58,7 @@ static char* command_generator(const char* text, int state)
     return nullptr;
 }
 
-char** shell_completion(const char* text, int start, int end)
+char** shell_completion(const char* text, int start, int /*end*/)
 {
     char** matches;
 

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -11,7 +11,7 @@ const char* shell_err_strings[] = {
     "too many args",
     "argument is too long",
     "double quote error",
-    NULL,
+    nullptr,
 };
 
 const char* shell_error_str(enum shell_error err)
@@ -19,7 +19,7 @@ const char* shell_error_str(enum shell_error err)
     return (shell_err_strings[err]);
 }
 
-static struct cmd_def** g_cmd_defs = NULL;
+static struct cmd_def** g_cmd_defs = nullptr;
 
 /** For completion.
  *
@@ -49,24 +49,24 @@ static char* command_generator(const char* text, int state)
 
         if (strncmp(name, text, len) == 0) {
             char* nptr = strdup(name);
-            assert(NULL != nptr);
+            assert(nullptr != nptr);
             return nptr;
         }
     }
 
     /* If no names matched, then return NULL. */
-    return ((char*)NULL);
+    return ((char*)nullptr);
 }
 
 char** shell_completion(const char* text, int start, int end)
 {
     char** matches;
 
-    if (NULL == g_cmd_defs) {
-        return NULL;
+    if (nullptr == g_cmd_defs) {
+        return nullptr;
     }
 
-    matches = (char**)NULL;
+    matches = (char**)nullptr;
 
     if (start == 0) {
         matches = rl_completion_matches(text, command_generator);
@@ -84,10 +84,10 @@ Shell::Shell()
         Shell::class_initialized = true;
     }
 
-    defs = NULL;
-    handle = NULL;
-    handle2 = NULL;
-    prompt = NULL;
+    defs = nullptr;
+    handle = nullptr;
+    handle2 = nullptr;
+    prompt = nullptr;
 }
 
 int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
@@ -119,7 +119,7 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
             }
         } else {
         retry:
-            ret = wait(0);
+            ret = wait(nullptr);
             if (-1 == ret) {
                 if (EINTR == errno) {
                     goto retry;
@@ -131,13 +131,13 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
         }
         return SHELL_CONT;
     }
-    if (NULL != (p = index(argv[0], '='))) {
+    if (nullptr != (p = index(argv[0], '='))) {
         *p++ = 0;
         return SHELL_CONT;
     }
     len = strlen(argv[0]);
 
-    def = NULL;
+    def = nullptr;
     found = 0;
     for (i = 0; defs[i] != nullptr; i++) {
         tmp = defs[i];
@@ -224,7 +224,7 @@ int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
                 sargc++;
             }
 
-            sargv[sargc] = NULL;
+            sargv[sargc] = nullptr;
 
             if (dblquote) {
                 if (errp != nullptr) {
@@ -266,7 +266,7 @@ int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
                 if ((sargc + 1) < SHELL_MAX_ARGV) {
                     sargv[sargc] = &sargmem[sargc][0];
                     sargc++;
-                    sargv[sargc] = NULL;
+                    sargv[sargc] = nullptr;
                     pos = 0;
                 } else {
                     if (errp != nullptr) {
@@ -330,7 +330,7 @@ void* Shell::get_handle2()
 void Shell::set_prompt(const char* prompt)
 {
     char* nprompt = strdup(prompt);
-    if (NULL == nprompt) {
+    if (nullptr == nprompt) {
         perror("strdup");
         exit(1);
     }
@@ -343,7 +343,7 @@ void Shell::loop()
     using_history();
 
     while (true) {
-        char* line = NULL;
+        char* line = nullptr;
 
         if ((line = readline(prompt)) != nullptr) {
             enum shell_error shell_err = SHELL_ERROR_NONE;

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -330,7 +330,7 @@ void Shell::loop()
         char* line = NULL;
 
         if ((line = readline(prompt))) {
-            enum shell_error shell_err;
+            enum shell_error shell_err = SHELL_ERROR_NONE;
             int ret;
 
             ret = parse(defs, line, &shell_err);

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -14,25 +14,17 @@ const char* shell_err_strings[] = {
     nullptr,
 };
 
-const char* shell_error_str(enum shell_error err)
+static const char* shell_error_str(enum shell_error err)
 {
     return (shell_err_strings[err]);
 }
 
 static struct cmd_def** g_cmd_defs = nullptr;
 
-/** For completion.
- *
- * @param defs
- */
-void shell_install_cmd_defs(struct cmd_def** defs)
-{
-    g_cmd_defs = defs;
-}
-
 static char* command_generator(const char* text, int state)
 {
-    static int list_index, len;
+    static int list_index;
+    static size_t len;
     const char* name;
     struct cmd_def* def;
 
@@ -58,7 +50,7 @@ static char* command_generator(const char* text, int state)
     return nullptr;
 }
 
-char** shell_completion(const char* text, int start, int /*end*/)
+static char** shell_completion(const char* text, int start, int /*end*/)
 {
     char** matches;
 
@@ -93,7 +85,8 @@ Shell::Shell()
 int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
 {
     struct cmd_def *def, *tmp;
-    int ret, len, found;
+    size_t len;
+    int ret, found;
     char* p;
     int i;
 
@@ -172,8 +165,8 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
  * Understands comments (sharp sign), double quotes, semicolon. ignore
  * whitspaces
  *
+ * @param defs the callback
  * @param str the input string
- * @param cmd the callback
  * @param errp the error code
  *
  * @return 0 if OK, -1 on failure
@@ -298,8 +291,6 @@ int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
         }
         str++;
     }
-
-    return 0;
 }
 
 void Shell::set_cmds(struct cmd_def** defs)

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -55,7 +55,7 @@ static char* command_generator(const char* text, int state)
     }
 
     /* If no names matched, then return NULL. */
-    return ((char*)nullptr);
+    return nullptr;
 }
 
 char** shell_completion(const char* text, int start, int end)
@@ -66,7 +66,7 @@ char** shell_completion(const char* text, int start, int end)
         return nullptr;
     }
 
-    matches = (char**)nullptr;
+    matches = nullptr;
 
     if (start == 0) {
         matches = rl_completion_matches(text, command_generator);

--- a/src/shell.h
+++ b/src/shell.h
@@ -26,8 +26,8 @@ enum shell_error {
 };
 
 #define SHELL_CONT 0
-#define SHELL_EPARSE -1
-#define SHELL_RETURN -2
+#define SHELL_EPARSE (-1)
+#define SHELL_RETURN (-2)
 
 class Shell;
 

--- a/src/shell.h
+++ b/src/shell.h
@@ -42,8 +42,8 @@ class Shell {
     Shell();
 
     void set_cmds(struct cmd_def** defs);
-    void set_handle(void* hande);
-    void set_handle2(void* hande);
+    void set_handle(void* handle);
+    void set_handle2(void* handle);
     void set_prompt(const char* prompt);
     void* get_handle();
     void* get_handle2();


### PR DESCRIPTION
This PR introduces and configures clang-tidy.

It also adds a "few" compiler flags to the Makefile.

This resolves https://github.com/vrancurel/quadiron/issues/7

Note that https://github.com/vrancurel/quadiron/pull/4 in included in this PR (otherwise I couldn't compile and tests the refactoring).