### PR TITLE
Add `-Wshadow` and fix a regression

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,7 @@ CFLAGS = \
 -Wnon-virtual-dtor \
 -Wold-style-cast \
 -Woverlength-strings \
+-Wshadow \
 -Wshift-sign-overflow \
 -Wstring-compare -Wstring-conversion -Wstring-plus-char \
 -Wsometimes-uninitialized \

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -415,18 +415,18 @@ class CBigNum {
         CBigNum bnBase(nBase);
         CBigNum bn0(0);
         std::string str;
-        CBigNum bn = *this;
-        BN_set_negative(bn.bn, 0);
+        CBigNum tmp = *this;
+        BN_set_negative(tmp.bn, 0);
         CBigNum dv;
         CBigNum rem;
-        if (BN_cmp(bn.bn, bn0.bn) == 0) {
+        if (BN_cmp(tmp.bn, bn0.bn) == 0) {
             return "0";
         }
-        while (BN_cmp(bn.bn, bn0.bn) > 0) {
-            if (BN_div(dv.bn, rem.bn, bn.bn, bnBase.bn, pctx) == 0) {
+        while (BN_cmp(tmp.bn, bn0.bn) > 0) {
+            if (BN_div(dv.bn, rem.bn, tmp.bn, bnBase.bn, pctx) == 0) {
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             }
-            bn = dv;
+            tmp = dv;
             uint64 c = rem.getulong();
             str += "0123456789abcdef"[c];
         }

--- a/src/kad_node.cpp
+++ b/src/kad_node.cpp
@@ -150,8 +150,8 @@ KadNode::find_nearest_nodes_local(const KadRoutable& routable, int amount)
         // Find remaining nearest nodes.
         for (int i = 1; i < (conf->n_bits + 1); i++) {
             if (bit_length != i) {
-                std::list<KadNode*>& list = buckets[i];
-                for (auto& it : list) {
+                std::list<KadNode*>& nodes = buckets[i];
+                for (auto& it : nodes) {
                     if (verbose) {
                         std::cout << "kbucket " << i << " "
                                   << it->get_id().ToString(16) << " distance="
@@ -218,11 +218,11 @@ std::list<KadNode*> KadNode::lookup(const KadRoutable& routable)
 
     // Send find_nodes.
     for (auto& starting_node : starting_nodes) {
-        std::list<KadNode*> answers =
+        std::list<KadNode*> nodes =
             starting_node->find_nearest_nodes(routable, conf->k);
 
         // Add to answers.
-        for (auto& answer : answers) {
+        for (auto& answer : nodes) {
             // Remove oneself from the list.
             if (get_id() != answer->get_id()) {
                 answers.push_back(answer);
@@ -280,11 +280,11 @@ std::list<KadNode*> KadNode::lookup(const KadRoutable& routable)
                 break;
             }
 
-            std::list<KadNode*> answers =
+            std::list<KadNode*> nodes =
                 (*it)->find_nearest_nodes(routable, conf->k);
 
             // Add to round_answers.
-            for (auto& answer : answers) {
+            for (auto& answer : nodes) {
                 // Remove oneself from the list.
                 if (get_id() != answer->get_id()) {
                     round_answers.push_back(answer);
@@ -340,11 +340,11 @@ std::list<KadNode*> KadNode::lookup(const KadRoutable& routable)
                     continue;
                 }
 
-                std::list<KadNode*> answers =
+                std::list<KadNode*> nodes =
                     (*it)->find_nearest_nodes(routable, conf->k);
 
                 // Add to answers.
-                for (auto& answer : answers) {
+                for (auto& answer : nodes) {
                     // Remove oneself from the list.
                     if (get_id() != answer->get_id()) {
                         answers.push_back(answer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (fname.empty()) {
+    if (!fname.empty()) {
         std::ifstream fin(fname);
         if (!fin.is_open()) {
             std::cerr << "unable to open " << fname << "\n";

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -79,7 +79,6 @@ Shell::Shell()
     defs = nullptr;
     handle = nullptr;
     handle2 = nullptr;
-    prompt = nullptr;
 }
 
 int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
@@ -318,15 +317,9 @@ void* Shell::get_handle2()
     return handle2;
 }
 
-void Shell::set_prompt(const char* prompt)
+void Shell::set_prompt(const std::string& prompt)
 {
-    char* nprompt = strdup(prompt);
-    if (nullptr == nprompt) {
-        perror("strdup");
-        exit(1);
-    }
-    free(this->prompt);
-    this->prompt = nprompt;
+    this->prompt = prompt;
 }
 
 void Shell::loop()
@@ -336,7 +329,7 @@ void Shell::loop()
     while (true) {
         char* line = nullptr;
 
-        if ((line = readline(prompt)) != nullptr) {
+        if ((line = readline(prompt.c_str())) != nullptr) {
             enum shell_error shell_err = SHELL_ERROR_NONE;
             int ret;
 

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -81,7 +81,7 @@ Shell::Shell()
     handle2 = nullptr;
 }
 
-int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
+int Shell::do_cmd(struct cmd_def** definitions, int argc, char** argv)
 {
     struct cmd_def *def, *tmp;
     size_t len;
@@ -131,8 +131,8 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
 
     def = nullptr;
     found = 0;
-    for (i = 0; defs[i] != nullptr; i++) {
-        tmp = defs[i];
+    for (i = 0; definitions[i] != nullptr; i++) {
+        tmp = definitions[i];
         if (strcmp(argv[0], tmp->name) == 0) {
             found = 1;
             def = tmp;
@@ -164,13 +164,16 @@ int Shell::do_cmd(struct cmd_def** defs, int argc, char** argv)
  * Understands comments (sharp sign), double quotes, semicolon. ignore
  * whitspaces
  *
- * @param defs the callback
+ * @param definitions the callback
  * @param str the input string
  * @param errp the error code
  *
  * @return 0 if OK, -1 on failure
  */
-int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
+int Shell::parse(
+    struct cmd_def** definitions,
+    char* str,
+    enum shell_error* errp)
 {
     int pos, ret;
     bool comment = false;
@@ -225,7 +228,7 @@ int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
                 return -1;
             }
 
-            if ((ret = do_cmd(defs, sargc, sargv)) != SHELL_CONT) {
+            if ((ret = do_cmd(definitions, sargc, sargv)) != SHELL_CONT) {
                 return ret;
             }
 
@@ -292,19 +295,19 @@ int Shell::parse(struct cmd_def** defs, char* str, enum shell_error* errp)
     }
 }
 
-void Shell::set_cmds(struct cmd_def** defs)
+void Shell::set_cmds(struct cmd_def** definitions)
 {
-    g_cmd_defs = this->defs = defs;
+    g_cmd_defs = this->defs = definitions;
 }
 
-void Shell::set_handle(void* handle)
+void Shell::set_handle(void* hdl)
 {
-    this->handle = handle;
+    this->handle = hdl;
 }
 
-void Shell::set_handle2(void* handle)
+void Shell::set_handle2(void* hdl)
 {
-    this->handle2 = handle;
+    this->handle2 = hdl;
 }
 
 void* Shell::get_handle()
@@ -317,9 +320,9 @@ void* Shell::get_handle2()
     return handle2;
 }
 
-void Shell::set_prompt(const std::string& prompt)
+void Shell::set_prompt(const std::string& ps1)
 {
-    this->prompt = prompt;
+    this->prompt = ps1;
 }
 
 void Shell::loop()

--- a/src/shell.h
+++ b/src/shell.h
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include <sys/wait.h>
 #include <unistd.h>
@@ -44,7 +45,7 @@ class Shell {
     void set_cmds(struct cmd_def** defs);
     void set_handle(void* handle);
     void set_handle2(void* handle);
-    void set_prompt(const char* prompt);
+    void set_prompt(const std::string& prompt);
     void* get_handle();
     void* get_handle2();
     void loop();
@@ -53,7 +54,7 @@ class Shell {
     struct cmd_def** defs;
     void* handle;
     void* handle2;
-    char* prompt;
+    std::string prompt;
     static bool class_initialized;
 
     int do_cmd(struct cmd_def** defs, int argc, char** argv);

--- a/src/shell.h
+++ b/src/shell.h
@@ -42,10 +42,10 @@ class Shell {
   public:
     Shell();
 
-    void set_cmds(struct cmd_def** defs);
-    void set_handle(void* handle);
-    void set_handle2(void* handle);
-    void set_prompt(const std::string& prompt);
+    void set_cmds(struct cmd_def** definitions);
+    void set_handle(void* hdl);
+    void set_handle2(void* hdl);
+    void set_prompt(const std::string& ps1);
     void* get_handle();
     void* get_handle2();
     void loop();
@@ -57,8 +57,8 @@ class Shell {
     std::string prompt;
     static bool class_initialized;
 
-    int do_cmd(struct cmd_def** defs, int argc, char** argv);
-    int parse(struct cmd_def** defs, char* str, enum shell_error* errp);
+    int do_cmd(struct cmd_def** definitions, int argc, char** argv);
+    int parse(struct cmd_def** definitions, char* str, enum shell_error* errp);
 };
 
 #endif


### PR DESCRIPTION
During the migration to CMake, I took a look to my personal set of compiler flags and added them.

Not much to say about that, except that one, `-Wshadow`, spouted some warnings which lead me to discover a regression introduced in 1327309a2a97aa6e328027e107fbcc34a17fe9c1 (where I introduced some `answers` variables that were hiding other ones with a wider scope).
