### PR TITLE
use a recent toolchain

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,15 +1,17 @@
 dependencies:
   post:
+    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo add-apt-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
     - sudo apt-get update
-    - sudo apt-get -y install clang-3.9 libargtable2-dev libjsoncpp-dev doxygen libmicrohttpd-dev libedit-dev
+    - sudo apt-get -y --no-install-recommends install clang-5.0 clang-tidy-5.0 libargtable2-dev libjsoncpp-dev doxygen libmicrohttpd-dev libedit-dev
+    - sudo ln -s /usr/bin/clang-tidy-5.0 /usr/bin/clang-tidy
+    - sudo ln -s /usr/bin/clang++-5.0 /usr/bin/clang++
     - git clone git://github.com/cinemast/libjson-rpc-cpp.git
     - cd libjson-rpc-cpp && git checkout v0.6.0
     - mkdir libjson-rpc-cpp/build
     - cd libjson-rpc-cpp/build && cmake -DCOMPILE_TESTS=No .. && make && sudo make install
     - sudo ldconfig
-    - sudo apt-get -y install clang-tidy-3.9
-    - sudo ln -s /usr/bin/clang-tidy-3.9 /usr/bin/clang-tidy
-    - sudo ln -s /usr/bin/clang++-3.9 /usr/bin/clang++
 
 compile:
   override:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char** argv)
         case 'B': {
             std::istringstream input(optarg);
             std::string bstrap;
-            while (std::getline(input, bstrap, ',')) {
+            while (!std::getline(input, bstrap, ',').fail()) {
                 bstraplist.push_back(bstrap);
             }
             break;


### PR DESCRIPTION
Thanks to apt.llvm.org it's quite easy to get LLVM 5.0 on Ubuntu 14.04 ☺
So let's do it (less false positives than the 3.9 toolchain).