### PR TITLE
use run-clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PACKAGE ${CMAKE_PROJECT_NAME})
 # Paths
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set(SCRIPT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scripts)
 set(GENERATE_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin/${CMAKE_BUILD_TYPE})
 
@@ -194,11 +195,6 @@ add_custom_target(format
 )
 add_dependencies(format ${PROJECT_NAME})
 
-# We still need these ones for the headers files (not in compile_commands.json).
-set(CLANG_LINT_OPTS
-  -x c++ --std=c++11
-  -isystem ${GENERATE_DIR}
-)
 set(CLANG_LINTS_LIST
   android-*
   boost-*
@@ -229,13 +225,13 @@ set(CLANG_LINTS_LIST
 string(REPLACE ";" "," CLANG_LINTS "${CLANG_LINTS_LIST}")
 
 add_custom_target(lint
-  COMMAND clang-tidy ${ALL_SRCS} -checks=${CLANG_LINTS} -p ${CMAKE_BINARY_DIR} -- ${CLANG_LINT_OPTS}
+  COMMAND ${SCRIPT_DIR}/run-clang-tidy.py -checks=${CLANG_LINTS} -header-filter=.*
   COMMENT "run the linter"
 )
 add_dependencies(lint ${PROJECT_NAME})
 
 add_custom_target(fix-lint
-  COMMAND clang-tidy -fix ${ALL_SRCS} -checks=${CLANG_LINTS} -p ${CMAKE_BINARY_DIR} -- ${CLANG_LINT_OPTS}
+  COMMAND ${SCRIPT_DIR}/run-clang-tidy.py -fix -checks=${CLANG_LINTS} -header-filter=.*
   COMMENT "run the linter and apply proposed fixes"
 )
 add_dependencies(fix-lint ${PROJECT_NAME})
@@ -248,7 +244,7 @@ add_dependencies(fix-lint ${PROJECT_NAME})
 # Should be no longer needed when https://reviews.llvm.org/D39105 is merged…
 set(LINT_ERROR_PATTERN "'(error|warning):'")
 add_custom_target(check-lint
-  COMMAND test `clang-tidy ${ALL_SRCS} -checks=${CLANG_LINTS} -p ${CMAKE_BINARY_DIR} -- ${CLANG_LINT_OPTS} | grep -Pc ${LINT_ERROR_PATTERN}` -eq 0
+  COMMAND test `${SCRIPT_DIR}/run-clang-tidy.py -checks=${CLANG_LINTS} -header-filter=.* | grep -Pc ${LINT_ERROR_PATTERN}` -eq 0
   COMMENT "check for lint errors"
 )
 add_dependencies(check-lint ${PROJECT_NAME})

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python2
+#
+#===- run-clang-tidy.py - Parallel clang-tidy runner ---------*- python -*--===#
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+#===------------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+from __future__ import print_function
+import argparse
+import json
+import multiprocessing
+import os
+import Queue
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+
+def find_compilation_database(path):
+  """Adjusts the directory until a compilation database is found."""
+  result = './'
+  while not os.path.isfile(os.path.join(result, path)):
+    if os.path.realpath(result) == '/':
+      print('Error: could not find compilation database.')
+      sys.exit(1)
+    result += '../'
+  return os.path.realpath(result)
+
+
+def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                        header_filter, extra_arg, extra_arg_before, quiet):
+  """Gets a command line for clang-tidy."""
+  start = [clang_tidy_binary]
+  if header_filter is not None:
+    start.append('-header-filter=' + header_filter)
+  else:
+    # Show warnings in all in-project headers by default.
+    start.append('-header-filter=^' + build_path + '/.*')
+  if checks:
+    start.append('-checks=' + checks)
+  if tmpdir is not None:
+    start.append('-export-fixes')
+    # Get a temporary file. We immediately close the handle so clang-tidy can
+    # overwrite it.
+    (handle, name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+    os.close(handle)
+    start.append(name)
+  for arg in extra_arg:
+      start.append('-extra-arg=%s' % arg)
+  for arg in extra_arg_before:
+      start.append('-extra-arg-before=%s' % arg)
+  start.append('-p=' + build_path)
+  if quiet:
+      start.append('-quiet')
+  start.append(f)
+  return start
+
+
+def check_clang_apply_replacements_binary(args):
+  """Checks if invoking supplied clang-apply-replacements binary works."""
+  try:
+    subprocess.check_call([args.clang_apply_replacements_binary, '--version'])
+  except:
+    print('Unable to run clang-apply-replacements. Is clang-apply-replacements '
+          'binary correctly specified?', file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
+
+
+def apply_fixes(args, tmpdir):
+  """Calls clang-apply-fixes on a given directory. Deletes the dir when done."""
+  invocation = [args.clang_apply_replacements_binary]
+  if args.format:
+    invocation.append('-format')
+  if args.style:
+    invocation.append('-style=' + args.style)
+  invocation.append(tmpdir)
+  subprocess.call(invocation)
+
+
+def run_tidy(args, tmpdir, build_path, queue):
+  """Takes filenames out of queue and runs clang-tidy on them."""
+  while True:
+    name = queue.get()
+    invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                     tmpdir, build_path, args.header_filter,
+                                     args.extra_arg, args.extra_arg_before,
+                                     args.quiet)
+    sys.stdout.write(' '.join(invocation) + '\n')
+    subprocess.call(invocation)
+    queue.task_done()
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '
+                                   'in a compilation database. Requires '
+                                   'clang-tidy and clang-apply-replacements in '
+                                   '$PATH.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-clang-apply-replacements-binary', metavar='PATH',
+                      default='clang-apply-replacements',
+                      help='path to clang-apply-replacements binary')
+  parser.add_argument('-checks', default=None,
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default')
+  parser.add_argument('-header-filter', default=None,
+                      help='regular expression matching the names of the '
+                      'headers to output diagnostics from. Diagnostics from '
+                      'the main file of each translation unit are always '
+                      'displayed.')
+  parser.add_argument('-j', type=int, default=0,
+                      help='number of tidy instances to be run in parallel.')
+  parser.add_argument('files', nargs='*', default=['.*'],
+                      help='files to be processed (regex on path)')
+  parser.add_argument('-fix', action='store_true', help='apply fix-its')
+  parser.add_argument('-format', action='store_true', help='Reformat code '
+                      'after applying fixes')
+  parser.add_argument('-style', default='file', help='The style of reformat '
+                      'code after applying fixes')
+  parser.add_argument('-p', dest='build_path',
+                      help='Path used to read a compile command database.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true',
+                      help='Run clang-tidy in quiet mode')
+  args = parser.parse_args()
+
+  db_path = 'compile_commands.json'
+
+  if args.build_path is not None:
+    build_path = args.build_path
+  else:
+    # Find our database
+    build_path = find_compilation_database(db_path)
+
+  try:
+    invocation = [args.clang_tidy_binary, '-list-checks']
+    invocation.append('-p=' + build_path)
+    if args.checks:
+      invocation.append('-checks=' + args.checks)
+    invocation.append('-')
+    print(subprocess.check_output(invocation))
+  except:
+    print("Unable to run clang-tidy.", file=sys.stderr)
+    sys.exit(1)
+
+  # Load the database and extract all files.
+  database = json.load(open(os.path.join(build_path, db_path)))
+  files = [entry['file'] for entry in database]
+
+  max_task = args.j
+  if max_task == 0:
+    max_task = multiprocessing.cpu_count()
+
+  tmpdir = None
+  if args.fix:
+    check_clang_apply_replacements_binary(args)
+    tmpdir = tempfile.mkdtemp()
+
+  # Build up a big regexy filter from all command line arguments.
+  file_name_re = re.compile('|'.join(args.files))
+
+  try:
+    # Spin up a bunch of tidy-launching threads.
+    queue = Queue.Queue(max_task)
+    for _ in range(max_task):
+      t = threading.Thread(target=run_tidy,
+                           args=(args, tmpdir, build_path, queue))
+      t.daemon = True
+      t.start()
+
+    # Fill the queue with files.
+    for name in files:
+      if file_name_re.search(name):
+        queue.put(name)
+
+    # Wait for all threads to be done.
+    queue.join()
+
+  except KeyboardInterrupt:
+    # This is a sad hack. Unfortunately subprocess goes
+    # bonkers with ctrl-c and we start forking merrily.
+    print('\nCtrl-C detected, goodbye.')
+    if args.fix:
+      shutil.rmtree(tmpdir)
+    os.kill(0, 9)
+
+  if args.fix:
+    print('Applying fixes ...')
+    successfully_applied = False
+
+    try:
+      apply_fixes(args, tmpdir)
+      successfully_applied = True
+    except:
+      print('Error applying fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+
+    shutil.rmtree(tmpdir)
+    if not successfully_applied:
+      sys.exit(1)
+
+if __name__ == '__main__':
+  main()

--- a/src/kad_routable.h
+++ b/src/kad_routable.h
@@ -14,7 +14,7 @@ enum RoutableType {
 
 class Routable {
   public:
-    Routable(const CBigNum& entity_id, enum RoutableType);
+    Routable(const CBigNum& entity_id, enum RoutableType entity_type);
 
     CBigNum get_id() const;
     bool is_remote();

--- a/test/bit_map.cpp
+++ b/test/bit_map.cpp
@@ -8,7 +8,7 @@
 #include "bit_map.h"
 #include "exceptions.h"
 
-TEST(BitMapTest, TestCheck)
+TEST(BitMapTest, TestCheck) // NOLINT(-*)
 {
     const uint32_t nb_bits = 16;
     kad::BitMap bitmap(nb_bits);
@@ -23,7 +23,7 @@ TEST(BitMapTest, TestCheck)
         << "can't call get_rand_uint on an exhausted BitMap";
 }
 
-TEST(BitMapTest, TestOutput)
+TEST(BitMapTest, TestOutput) // NOLINT(-*)
 {
     const uint32_t nb_bits = 16;
     kad::BitMap bitmap(nb_bits);


### PR DESCRIPTION
`run-clang-tidy.py` is a Python script packaged with clang-tidy.

The advantages over running clang-tidy by ourself are:
- automatically run the linter on every files of the project (using the
compilation database)
- run several instance of clang-tidy in parallel (on my machine, the
time to lint the project is halved).

The drawback is that I didn't find an easy way to tell him to ignore
some files (namely our tests that use GoogleTest's macros) so we have to
manually disable the lint on the tests for now.

I think the advantages outweights the drawbacks, so let's move to
`run-clang-tidy.py`.