### PR TITLE
remove useless exclude in Doxyfile

### DIFF
--- a/documentation/Doxyfile.in
+++ b/documentation/Doxyfile.in
@@ -835,9 +835,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @SOURCE_DIR@/config.h    \
-                         @SOURCE_DIR@/nodeclient.h \
-                         @SOURCE_DIR@/gethclient.h
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1674,7 +1672,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = amsmath
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first


### PR DESCRIPTION
These files are no longer generated in the source director.
Also add amsmath, if we want to write so pretty equation in LaTeX.