### PR TITLE
Use NTTEC in QuadIron

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,6 @@ set(SHARED_LIB ${CMAKE_PROJECT_NAME}_shared)
 set(STATIC_LIB ${CMAKE_PROJECT_NAME}_static)
 
 file(MAKE_DIRECTORY ${GENERATE_DIR})
-# Use SYSTEM so that our strict compilers settings are not applied to generated
-# code.
-include_directories(SYSTEM
-    ${GENERATE_DIR}
-)
 
 ####################
 # Default build type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin/${CMAKE_BUILD_TYPE})
 
 # Targets
 set(JSON_RPC_STUB jsonrpcstup)
-set(OBJECT_LIB ${CMAKE_PROJECT_NAME}_object)
-set(SHARED_LIB ${CMAKE_PROJECT_NAME}_shared)
-set(STATIC_LIB ${CMAKE_PROJECT_NAME}_static)
+set(OBJECT_LIB object)
+set(SHARED_LIB shared)
+set(STATIC_LIB static)
 
 file(MAKE_DIRECTORY ${GENERATE_DIR})
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The following targets are available:
 - `lint`: run the linter
 - `fix-lint`: run the linter and try to apply the proposed fixes
 - `quadiron`: build the QuadIron binary
-- `quadiron_shared`: build the QuadIron shared library
-- `quadiron_static`: build the QuadIron static library
-- `quadiron_test`: build the test driver
+- `shared`: build the QuadIron shared library
+- `static`: build the QuadIron static library
+- `unit_tests`: build the unit tests
 - `check`: run the test suite
 
 ### Code coverage

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Decentralized Storage with the Ethereum Blockchain
 - OpenSSL
 - readline
 - [libjson-rpc-cpp](https://github.com/cinemast/libjson-rpc-cpp)
+- [NTTEC](https://github.com/vrancurel/nttec)
 
 ## Build
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,9 @@ dependencies:
     - cd libjson-rpc-cpp && git checkout v0.6.0
     - mkdir libjson-rpc-cpp/build
     - cd libjson-rpc-cpp/build && cmake -DCOMPILE_TESTS=No .. && make && sudo make install
+    - git clone git@github.com:vrancurel/nttec.git
+    - mkdir nttec/build
+    - cd nttec/build && cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release .. && sudo make install
     - sudo ldconfig
 
 compile:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,20 +22,54 @@ configure_file(${SOURCE_DIR}/config.in ${GENERATE_DIR}/config.h @ONLY)
 # Libraries
 ###########
 
+# Dependencies.
+find_package(OpenSSL          REQUIRED)
+find_package(Readline         REQUIRED)
+find_package(JsonRpcCppClient REQUIRED)
+
+set(OBJECT_SYS_INCLUDES
+  ${GENERATE_DIR}
+  ${OPENSSL_INCLUDE_DIR}
+  ${JsonRpcCppClient_INCLUDE_DIRS}
+  ${Readline_INCLUDE_DIRS}
+)
+
+set(OBJECT_INCLUDES
+  ${SOURCE_DIR}
+)
+
 # Build an Object Library (can be reused for both static and dynamic libs).
 add_library(${OBJECT_LIB} OBJECT ${LIB_SRC})
 add_coverage(${OBJECT_LIB})
 set_property(TARGET ${OBJECT_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
+target_include_directories(${OBJECT_LIB} SYSTEM PUBLIC ${OBJECT_SYS_INCLUDES})
+target_include_directories(${OBJECT_LIB}        PUBLIC ${OBJECT_INCLUDES})
+target_compile_definitions(${OBJECT_LIB}
+  PUBLIC HAVE_READLINE=1
+)
 add_dependencies(${OBJECT_LIB}
   ${JSON_RPC_STUB}
 )
 
 # Dynamic library.
 add_library(${SHARED_LIB} SHARED $<TARGET_OBJECTS:${OBJECT_LIB}>)
-set_target_properties(${SHARED_LIB} PROPERTIES OUTPUT_NAME ${CMAKE_PROJECT_NAME})
 # Static library.
 add_library(${STATIC_LIB} STATIC $<TARGET_OBJECTS:${OBJECT_LIB}>)
-set_target_properties(${STATIC_LIB} PROPERTIES OUTPUT_NAME ${CMAKE_PROJECT_NAME})
+
+foreach(lib ${SHARED_LIB} ${STATIC_LIB})
+  set_target_properties(${lib} PROPERTIES OUTPUT_NAME ${CMAKE_PROJECT_NAME})
+  target_include_directories(${lib} SYSTEM PUBLIC ${OBJECT_SYS_INCLUDES})
+  target_include_directories(${lib}        PUBLIC ${OBJECT_INCLUDES})
+  target_compile_definitions(${lib}
+    PUBLIC $<TARGET_PROPERTY:${OBJECT_LIB},COMPILE_DEFINITIONS>
+  )
+
+  target_link_libraries(${lib}
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${Readline_LIBRARIES}
+    ${JsonRpcCppClient_LIBRARIES}
+  )
+endforeach()
 
 ############
 # Executable
@@ -43,30 +77,12 @@ set_target_properties(${STATIC_LIB} PROPERTIES OUTPUT_NAME ${CMAKE_PROJECT_NAME}
 
 set(EXECUTABLE_NAME ${CMAKE_PROJECT_NAME})
 
-# Dependencies.
-find_package(OpenSSL          REQUIRED)
-find_package(Readline         REQUIRED)
-find_package(JsonRpcCppClient REQUIRED)
-
-add_definitions(-DHAVE_READLINE)
-
 add_executable(${EXECUTABLE_NAME}
   ${SOURCE_DIR}/main.cpp
 )
 add_coverage(${EXECUTABLE_NAME})
 
-target_include_directories(${EXECUTABLE_NAME}
-    SYSTEM
-    PUBLIC
-    ${OPENSSL_INCLUDE_DIR}
-    ${JsonRpcCppClient_INCLUDE_DIRS}
-    ${Readline_INCLUDE_DIRS}
-)
-
 # Link librairies.
 target_link_libraries(${EXECUTABLE_NAME}
   ${STATIC_LIB}
-  ${OPENSSL_CRYPTO_LIBRARY}
-  ${Readline_LIBRARIES}
-  ${JsonRpcCppClient_LIBRARIES}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,12 +26,19 @@ configure_file(${SOURCE_DIR}/config.in ${GENERATE_DIR}/config.h @ONLY)
 find_package(OpenSSL          REQUIRED)
 find_package(Readline         REQUIRED)
 find_package(JsonRpcCppClient REQUIRED)
+find_package(NTTEC            REQUIRED)
+
+get_property(NTTEC_INCLUDE_DIRS
+  TARGET   NTTEC::static
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+)
 
 set(OBJECT_SYS_INCLUDES
   ${GENERATE_DIR}
   ${OPENSSL_INCLUDE_DIR}
   ${JsonRpcCppClient_INCLUDE_DIRS}
   ${Readline_INCLUDE_DIRS}
+  ${NTTEC_INCLUDE_DIRS}
 )
 
 set(OBJECT_INCLUDES
@@ -68,6 +75,7 @@ foreach(lib ${SHARED_LIB} ${STATIC_LIB})
     ${OPENSSL_CRYPTO_LIBRARY}
     ${Readline_LIBRARIES}
     ${JsonRpcCppClient_LIBRARIES}
+    NTTEC::static
   )
 endforeach()
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,12 +5,20 @@
 #include <vector>
 
 #include <getopt.h>
+#include <nttec/nttec.h>
 
 #include "quadiron.h"
 
+[[noreturn]] static void show_version()
+{
+    std::cout << PACKAGE << " (" << VERSION << ")\n"
+              << "using NTTEC " << nttec::get_version() << '\n';
+    exit(0);
+}
+
 [[noreturn]] static void usage()
 {
-    std::cerr << "usage: " << PACKAGE << " (" << VERSION << ")\n";
+    std::cerr << "usage: " << PACKAGE << '\n';
     std::cerr << "\t-b\tn_bits\n";
     std::cerr << "\t-k\tKademlia K parameter\n";
     std::cerr << "\t-a\tKademlia alpha parameter\n";
@@ -20,6 +28,7 @@
     std::cerr << "\t-B\tbootstrap list (comma-separated list of IPs)\n";
     std::cerr << "\t-N\tnumber of files\n";
     std::cerr << "\t-S\trandom seed\n";
+    std::cerr << "\t-V\tshow version\n";
     exit(1);
 }
 
@@ -45,7 +54,7 @@ int main(int argc, char** argv)
 
     opterr = 0;
 
-    while ((c = getopt(argc, argv, "b:k:a:n:c:g:B:S:f:N:")) != -1) {
+    while ((c = getopt(argc, argv, "b:k:a:n:c:g:B:S:f:N:V")) != -1) {
         switch (c) {
         case 'b':
             n_bits = kad::stou32(optarg);
@@ -82,6 +91,8 @@ int main(int argc, char** argv)
         case 'N':
             n_files = kad::stou32(optarg);
             break;
+        case 'V':
+            show_version();
         case '?':
         default:
             usage();
@@ -124,9 +135,7 @@ int main(int argc, char** argv)
 
     shell.set_cmds(kad::cmd_defs);
     shell.set_handle(&network);
-    std::ostringstream prompt;
-    prompt << PACKAGE << "> ";
-    shell.set_prompt(prompt.str());
+    shell.set_prompt(std::string(PACKAGE) + "> ");
     shell.loop();
 
     return EXIT_SUCCESS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,7 @@ set(TEST_SRC
   FORCE
 )
 
-set(TEST_DRIVER ${CMAKE_PROJECT_NAME}_test)
+set(TEST_DRIVER unit_tests)
 add_executable(${TEST_DRIVER}
   ${TEST_SRC}
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ ExternalProject_Add(gtest
 
 # Get paths of the installed GoogleTest.
 ExternalProject_Get_Property(gtest source_dir binary_dir)
+set(GTEST_SOURCE_DIR ${source_dir})
 
 # GoogleTest target (to be used as a dependency by our test driver).
 add_library(libgtest IMPORTED STATIC GLOBAL)
@@ -35,12 +36,6 @@ add_dependencies(libgmock gtest)
 set_target_properties(libgmock PROPERTIES
     "IMPORTED_LOCATION" "${binary_dir}/googlemock/libgmock.a"
     "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-)
-
-# Use SYSTEM so that our strict compilers settings are not applied on this code.
-include_directories(SYSTEM
-    "${source_dir}/googletest/include"
-    "${source_dir}/googlemock/include"
 )
 
 ###########################################################################
@@ -105,11 +100,14 @@ add_executable(${TEST_DRIVER}
 )
 add_coverage(${TEST_DRIVER})
 
-include_directories(${SOURCE_DIR})
-
 target_link_libraries(${TEST_DRIVER}
   libgtest
   ${STATIC_LIB}
+)
+# Use SYSTEM so that our strict compilers settings are not applied on this code.
+target_include_directories(${TEST_DRIVER} SYSTEM
+    PUBLIC "${GTEST_SOURCE_DIR}/googletest/include"
+    PUBLIC "${source_dir}/googlemock/include"
 )
 
 GTEST_ADD_TESTS(${TEST_DRIVER} "" ${TEST_SRC})


### PR DESCRIPTION
Because NTTEC export its configuration, we can simply call `find_package` to use it.

This PR also contains some improvements for the build system (better dependecies handling, remove redundant prefix, …)

Note that this PR won't work until https://github.com/vrancurel/nttec/pull/172 and https://github.com/vrancurel/nttec/pull/174 are merged.